### PR TITLE
feat(federation): rename OIDC entries to prepare Open Cloud Mesh & Federation 

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -112,9 +112,7 @@ fn git_status() {
     // built this artifact" is load-bearing (release provenance,
     // release-note automation).
     if env::var("CI").is_ok() {
-        println!(
-            "cargo:warning=OxiCloud built with git hash: {git_hash} and branch: {git_branch}"
-        );
+        println!("cargo:warning=OxiCloud built with git hash: {git_hash} and branch: {git_branch}");
     }
 }
 

--- a/docs/config/env.md
+++ b/docs/config/env.md
@@ -222,6 +222,7 @@ See the [OIDC configuration guide](/config/oidc) for details.
 | `OXICLOUD_OIDC_SCOPES` | `openid profile email` | Requested scopes |
 | `OXICLOUD_OIDC_FRONTEND_URL` | `http://localhost:8086` | Frontend URL to redirect to after login |
 | `OXICLOUD_OIDC_AUTO_PROVISION` | `true` | Auto-create users on first SSO login (JIT provisioning) |
+| `OXICLOUD_OIDC_AUTO_LINK_EMAIL_MATCH` | `true` | When subject-lookup misses on an OIDC login BUT the IdP-returned email (with `email_verified=true`) matches an existing local user (after `+alias` normalization), auto-link the OIDC identity to that user instead of refusing. Refuses on ambiguity (>1 local user normalises to same email) or if the matched user is already linked to a different identity. Safe under single-IdP trust model (admin chose the IdP); unsafe for future multi-IdP federation. Set `false` for postures requiring explicit consent for every link. See [OIDC account linking plan](../plan/oidc-account-linking.md). |
 | `OXICLOUD_OIDC_ADMIN_GROUPS` | — | Comma-separated OIDC groups that grant admin role |
 | `OXICLOUD_OIDC_DISABLE_PASSWORD_LOGIN` | `false` | **DEPRECATED** — emits boot warning; slated for removal in next major release. Use `OXICLOUD_AUTH_METHODS=oidc` (and optionally `OXICLOUD_AUTH_POLICIES=auto_redirect_if_standalone_oidc` for server-side `/login` redirect) instead. Still removes `password` from the effective allowlist when set to `true` — kept working so upgrading deployments don't break. |
 | `OXICLOUD_OIDC_PROVIDER_NAME` | `SSO` | Display name for the provider shown in UI |

--- a/docs/config/oidc.md
+++ b/docs/config/oidc.md
@@ -47,6 +47,7 @@ OXICLOUD_OIDC_PROVIDER_NAME="Authentik"
 | `OXICLOUD_OIDC_SCOPES` | `openid profile email` | Requested scopes |
 | `OXICLOUD_OIDC_FRONTEND_URL` | `http://localhost:8086` | Where to redirect the browser after auth |
 | `OXICLOUD_OIDC_AUTO_PROVISION` | `true` | Auto-create users on first login |
+| `OXICLOUD_OIDC_AUTO_LINK_EMAIL_MATCH` | `true` | Auto-link existing local users to their OIDC identity when the IdP-returned email (with `email_verified=true`) matches an existing local account. See narrative below. |
 | `OXICLOUD_OIDC_ADMIN_GROUPS` | — | OIDC groups that grant admin role |
 | `OXICLOUD_OIDC_DISABLE_PASSWORD_LOGIN` | `false` | **DEPRECATED** — use `OXICLOUD_AUTH_METHODS=oidc` instead. Emits a boot warning; slated for removal in next major release. |
 | `OXICLOUD_OIDC_PROVIDER_NAME` | `SSO` | Label shown on the login button |
@@ -68,10 +69,26 @@ If `OXICLOUD_OIDC_ENABLED=true` but `issuer_url`, `client_id`, or `client_secret
 
 OIDC users are matched by the pair:
 
-- `oidc_provider`
-- `oidc_subject`
+- `federation_issuer` (the id_token `iss` claim, canonical issuer URL)
+- `federation_subject` (the id_token `sub` claim)
 
 This allows one external identity to map to one local user record and supports just-in-time provisioning when `OXICLOUD_OIDC_AUTO_PROVISION=true`.
+
+### Auto-linking existing local users
+
+When `OXICLOUD_OIDC_AUTO_LINK_EMAIL_MATCH=true` (default) and the subject-based lookup misses on an OIDC login, OxiCloud tries to match by the IdP-returned email address instead. If exactly one local user's email matches (under `+alias`-stripping normalization) AND the IdP returned `email_verified=true`, the OIDC identity is auto-linked to that existing user — no admin round-trip, no manual SQL, no self-service flow needed. Great UX for enabling SSO on top of an existing user base.
+
+Refusal cases (fall through to the standard "email already exists" error):
+
+- `email_verified=false` on the IdP claims — audit event `federation.auto_link_refused` with `reason=auto_link_email_not_verified`.
+- More than one local user's email normalizes to the same value (rare but possible with `alice@example.com` and `alice+work@example.com`) — refused as `email_ambiguous`.
+- The matched user is already linked to a different OIDC identity — refused as `already_linked_elsewhere`.
+
+Security model: safe under OxiCloud's single-IdP configuration (admin explicitly chose and configured the IdP; the `email_verified` gate means the IdP has vouched for the user's ownership of that email). NOT safe for future multi-IdP federation where any WebFinger-discovered IdP is accepted — deferred to that flow.
+
+For users who need explicit consent for every OIDC link (compliance requirements), set `OXICLOUD_OIDC_AUTO_LINK_EMAIL_MATCH=false`. The self-service link flow (profile page "Connect Single Sign-On" button) remains available regardless.
+
+Full decision tree and safety-check details in [`docs/plan/oidc-account-linking.md`](../plan/oidc-account-linking.md).
 
 ## Provider Examples
 

--- a/docs/plan/federated-login.md
+++ b/docs/plan/federated-login.md
@@ -1,0 +1,419 @@
+# Federated Login — Autodiscovery Without RP Registration
+
+The goal: a user types `alice@example.com` (or a URL), OxiCloud discovers
+their identity provider via a well-known probe on `example.com`, initiates
+whatever auth flow that provider speaks, and gets back a stable
+`(issuer, subject)` pair. **Zero pre-registration of OxiCloud with every
+provider.** Fully-meshed federation — no social-login intermediary.
+
+This is separate from [OCM](./ocm.md) which federates SHARED RESOURCES
+between clouds. Federated login federates IDENTITY: authenticating a user
+whose home isn't ours.
+
+## Why "no RP registration" matters
+
+Every social-login flow today (Google Sign-In, Sign in with Apple, GitHub
+OAuth) requires the RP to register upfront in the provider's admin console:
+get a client_id, configure redirect URIs, get approval. This works for
+centralized RPs but breaks the mesh: every OxiCloud instance would need to
+register with every user's IdP.
+
+The dream is what BrowserID *almost* was — RP discovers identity
+provisioning from the user's domain, no bilateral setup, works for anyone
+who hosts an identity endpoint.
+
+## Landscape — sorted by fit and status
+
+### Alive and directly-useful
+
+**IndieAuth (W3C, active spec)** — literal answer to the "no registration"
+ask. Discovery via HTML `<link rel="authorization_endpoint">` on the
+identity URL. The **RP's URL IS its client identifier** — no registration
+step. Auth flow returns a `me` URL as canonical identity.
+- Ecosystem: strong in IndieWeb (Aperture, Micropub servers, IndieAuth.com).
+- Adoption outside IndieWeb: thin.
+- Best for: small-mesh federation of self-hosted OIDC-adjacent IdPs.
+- Fails for: users whose IdP is Google / Microsoft.
+
+**WebFinger (RFC 7033)** — user-supplied discovery.
+`GET https://example.com/.well-known/webfinger?resource=acct:alice@example.com`
+returns a JRD listing the identity's endpoints, including
+`rel="http://openid.net/specs/connect/1.0/issuer"` → OIDC issuer URL.
+- NOT a login mechanism, just a discovery layer.
+- Deployed at scale (Mastodon uses it for account discovery).
+- Pair with OIDC or IndieAuth for the actual login.
+
+**OIDC Dynamic Client Registration (RFC 7591 + OIDC Registration 1.0)** —
+machine-driven RP registration. RP POSTs to `registration_endpoint`
+(advertised in OIDC discovery) with its metadata, gets back `client_id` /
+`client_secret`. Fully server-to-server, no admin console.
+- Support matrix:
+  - ✅ Keycloak, Authentik, Zitadel, Kanidm, Ory Hydra
+  - ⚠️ Auth0, Okta (with policy configuration)
+  - ❌ Google, Microsoft/Entra, Facebook (disabled by policy)
+- The pragmatic bridge between "no registration" and "OIDC ecosystem."
+  Works with essentially every self-hosted OIDC server.
+
+**OpenID Federation 1.0 (finalized 2024)** — the STANDARDIZED future.
+Each entity publishes a signed entity statement at
+`/.well-known/openid-federation`; trust chains built through federation
+authorities (trust anchors). Designed for RP-IdP federation at scale
+without pairwise registration.
+- Adoption: EU eIDAS 2.0 wallets, GAIN identity network (banking).
+- Complexity: needs a trust-anchor infrastructure to be meaningful.
+- Timeline for OxiCloud: watch, don't implement Day 1.
+
+**Solid-OIDC** — Solid project's OIDC extension where `client_id` is a
+dereferenceable URL. Same trick as IndieAuth applied to full OIDC.
+- Deployed in Solid ecosystem (Inrupt); minimal outside it.
+- Reasonable to support as a variant of the IndieAuth strategy if demand
+  materialises.
+
+### Dead or dying — do not build against
+
+**Mozilla Persona / BrowserID (2011-2016)** — was almost exactly this
+plan. RP fetched `example.com/.well-known/browserid`, got the primary
+IdP's signing key, redirected user to primary, primary signed an assertion
+`{email, iss, sub}`, RP verified signature. Zero RP registration. Elegant
+design. **Killed by mainstream mail providers refusing to run primaries**;
+Mozilla's fallback (their own primary verifying via email link) undermined
+the security story. Lesson for us: any scheme requiring the user's domain
+to host an identity endpoint depends on domain operators playing along —
+they mostly don't for public email.
+
+**OpenID 2.0 (2007-2014)** — original OpenID with XRDS discovery,
+user-entered URL as identifier, full autodiscovery, no client registration
+required. Killed by OIDC (which requires registration). Some legacy
+support in Drupal, MediaWiki. Do not build new.
+
+**XRI / i-names / OpenXRI** — attempted "personal domain" identifiers with
+`=name` / `@name` prefixes. Never gained traction. Standards body
+dissolved. Dead.
+
+**WebID+TLS** — Solid predecessor. Client certificate-based, no client_id
+needed at all. Academic circles only. Dead outside research.
+
+**SXIP** — early single-sign-on protocol, pre-OpenID. Dead.
+
+**Self-Issued OP (SIOP) v1** — wallet-based auth where the user's device
+is the IdP. Cool idea, too complicated for a browser-only flow, requires
+wallet software installed. **v2 is emerging** in EU eIDAS 2.0 context but
+not for our use case.
+
+**Verifiable Credentials + SIOP v2** — the OIDC-flavored VC world. Right
+now: infrastructure-heavy (trust registries, credential formats), user
+must have a wallet. Watch for the eIDAS 2.0 rollout in 2026-2027; not yet
+right for us.
+
+### Adjacent but not this problem
+
+**OCM invitation flow** — federates SHARED RESOURCES, not identity. See
+[ocm.md](./ocm.md). Different plan.
+
+**OAuth 2.0 device flow (RFC 8628)** — solves "log in on a TV using your
+phone." Not autodiscovery.
+
+## OxiCloud strategy — WebFinger + strategy-per-provider
+
+Compose the alive-and-useful pieces:
+
+```
+alice@example.com
+  ↓
+discover(identifier)
+  ├─ WebFinger probe on example.com (RFC 7033)
+  │    → JRD lists rel="…/openid/1.0/issuer" → OIDC issuer URL
+  │    → JRD lists rel="…/indieauth/…" → IndieAuth authorization_endpoint
+  │    → both = choose OIDC (richer), fall back to IndieAuth on OIDC failure
+  │
+  ├─ If WebFinger returns 404 / no useful rel:
+  │    HTML fetch of identity URL, parse <link rel="authorization_endpoint">
+  │    → IndieAuth flow
+  │
+  └─ Else: hard-fail with actionable message
+       "No autodiscovery signal at example.com. Options:
+        (a) ask your admin to enable WebFinger/OIDC on your domain;
+        (b) ask this OxiCloud admin to pre-register example.com;
+        (c) use a supported IdP account."
+```
+
+**Strategy A — OIDC + Dynamic Registration:**
+
+```
+Discovered issuer URL → fetch /.well-known/openid-configuration
+  ↓
+Cache lookup: auth.oidc_dynamic_clients WHERE issuer = ?
+  ├─ hit  → reuse cached client_id + client_secret
+  └─ miss → POST registration_endpoint {redirect_uris, client_name, …}
+            get client_id + client_secret → cache row
+  ↓
+Normal OIDC authorize / callback / token flow (PKCE, nonce, etc.)
+  ↓
+id_token → federation_kind='oidc', federation_issuer=iss, federation_subject=sub
+```
+
+**Strategy B — IndieAuth (fallback):**
+
+```
+Discovered authorization_endpoint URL (and token_endpoint from same discovery)
+  ↓
+Redirect user with client_id = OxiCloud's own URL, redirect_uri, state, PKCE
+  ↓
+User consents on their IdP
+  ↓
+Callback with code → POST to token_endpoint
+  ↓
+Response has { me: "https://alice.example.com" }
+  ↓
+Store federation_kind='indieauth',
+      federation_issuer=example.com (domain from `me`),
+      federation_subject=me URL
+```
+
+**Strategy C — pre-registered (existing OIDC config):** the current
+single-IdP configured via `OXICLOUD_OIDC_ISSUER_URL` etc. Continues to
+work; discovery bypassed for that specific issuer. Handles Google /
+Microsoft cases where dynamic registration isn't available — admin
+pre-registers, users still get autodiscovery for the "which issuer" step.
+
+## Schema compatibility — the identity triple already covers this
+
+The federation-identity model from
+[ocm.md § Identity & auth model](./ocm.md) uses
+`(federation_kind, federation_issuer, federation_subject)`. **All the alive
+strategies fit cleanly** — no schema surgery per strategy, just one CHECK
+constraint update to admit new `federation_kind` values.
+
+| Strategy | federation_kind | federation_issuer | federation_subject |
+|---|---|---|---|
+| Magic-link (existing) | `magic_link` | NULL | NULL (identity is local `email`) |
+| OIDC (existing + dynamic) | `oidc` | id_token `iss` (issuer URL) | id_token `sub` |
+| IndieAuth | `indieauth` | domain from `me` URL | full `me` URL |
+| OCM (planned) | `ocm` | peer domain | federated address |
+| OpenID Federation (future) | `openid_fed` | entity-statement `sub` (issuer) | subject id |
+
+Extending the enum when a strategy lands is a one-line migration:
+
+```sql
+ALTER TABLE auth.users DROP CONSTRAINT users_federation_kind_check;
+ALTER TABLE auth.users ADD  CONSTRAINT users_federation_kind_check
+    CHECK (federation_kind IN ('magic_link','oidc','indieauth','ocm','openid_fed'));
+```
+
+BCL revocation, anti-duplicate lookup, session middleware, and the AuthZ
+engine all key on the triple — kind-blind. Adding IndieAuth or OpenID
+Federation touches ONLY the discovery + auth-flow code, never the identity
+storage or authorization layers.
+
+## What we'd add on top
+
+**For Strategy A:**
+
+```sql
+CREATE TABLE auth.oidc_dynamic_clients (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    issuer          TEXT NOT NULL UNIQUE,   -- keyed on issuer URL
+    client_id       TEXT NOT NULL,
+    client_secret   TEXT NOT NULL,          -- encrypted at rest (blob-encryption path)
+    registered_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    metadata        JSONB                   -- full registration response, for audit
+);
+```
+
+Cache of "IdPs we've dynamically registered with." First login per issuer
+pays ~500ms for the registration round-trip; subsequent logins hit the
+cache.
+
+**For Strategy B:** no new table. Client identifier is our URL, discovery
+metadata is small enough to cache in moka with a short TTL.
+
+**For discovery layer (shared):** small in-memory + DB cache of
+`(identifier → strategy + endpoint URLs)` with a TTL matching provider
+metadata freshness (typical: 1 hour for OIDC discovery per its `Cache-Control`
+guidance).
+
+## Trust boundary — policy switch, not a hard-coded stance
+
+Open discovery = we accept logins from ANY IdP on ANY domain. Three modes,
+per admin choice:
+
+**Open federation** (default for personal / community deployments) — allow
+any WebFinger-discovered IdP. Trust is per-user (user chose to authenticate
+via that IdP; we trust their choice). Simplest UX, largest attack surface.
+A malicious IdP can mint arbitrary `sub`s and claim any identity WITHIN
+ITS OWN DOMAIN (can't impersonate other domains — the `(iss, sub)` key
+scopes damage). This is the same trust posture as accepting any email
+address from an SMTP server today.
+
+**Allowlist federation** (default for enterprise) — admin-managed
+`ocm.trusted_peers` (reuse the OCM peer allowlist, or a sibling table
+`auth.trusted_federation_domains`). Only auto-discover for listed
+domains. Kills the "just enter your email" UX but bounds the attack
+surface.
+
+**Hybrid** — allow-by-default with per-user quotas + rate limits + admin
+visibility (`GET /api/admin/federation/discovered_peers` shows every
+domain we've ever registered against, with revoke button). Middle ground.
+
+Config knob:
+
+```
+OXICLOUD_AUTH_FEDERATION_MODE=open|allowlist|hybrid  # default: hybrid
+OXICLOUD_AUTH_FEDERATION_ALLOWLIST=domain1.com,domain2.com   # allowlist mode
+```
+
+## Same discovery layer serves invitation
+
+The `discover(identifier) → Strategy` function is not just for login — it
+answers the same question at INVITE time. When a local user shares with
+`alice@example.com`, the invite flow probes her domain and picks the
+strongest available channel:
+
+```
+share_with_external(alice@example.com)
+  ↓
+discover(alice@example.com)
+  ├─ OCM signal on example.com  → OCM outbound share (resource stays here,
+  │                                 she consumes via her own cloud). Grant
+  │                                 tied to `federation_kind='ocm'`.
+  ├─ OIDC + dynamic reg supported → mint a magic-link that triggers OIDC
+  │                                  auth on redemption. Grant tied to
+  │                                  `federation_kind='oidc'` on first login.
+  ├─ IndieAuth signal            → magic-link that triggers IndieAuth on
+  │                                  redemption. Grant tied to
+  │                                  `federation_kind='indieauth'`.
+  ├─ OpenID Federation           → same idea, `federation_kind='openid_fed'`.
+  └─ Nothing discoverable        → traditional email magic-link, mailbox-
+                                    strength trust. Grant tied to
+                                    `federation_kind='magic_link'`.
+```
+
+**Preference ordering** (strongest → weakest):
+
+| Channel | Trust source | Why higher |
+|---|---|---|
+| OCM | Peer server + user's own auth on their cloud | Resource federation + strong identity |
+| OpenID Federation | Signed entity statement + trust anchor chain | Cryptographic RP-IdP trust |
+| OIDC + dynamic reg | User's IdP (potentially MFA, hardware keys) | IdP-mediated identity |
+| IndieAuth | User's domain (same domain owns identity + endpoint) | Domain-owner attestation |
+| Magic-link | Mailbox possession only | Weakest — no MFA, phishable |
+
+The share dialog UX shows a small badge on the resolved recipient
+indicating the channel that will be used: `Federated cloud` (OCM),
+`SSO via IdP.example.com` (OIDC), `IndieAuth on example.com`, or
+`Email link` (magic-link fallback). Sender sees the trust posture
+before sending; receiver's invite email / OCM notification reflects
+the same.
+
+**Cache the discovery outcome per identifier for a short TTL** (e.g. 24h
+with revalidation) so repeated invites to the same person don't repeat
+the probe. Cache lives in `auth.federated_identity_discovery` with
+columns `(identifier, discovered_kind, discovered_endpoints, cached_at,
+expires_at)`. Invalidated eagerly if the invite fails (endpoint
+disappeared, IdP rejected registration) — next attempt re-probes.
+
+**Trust-mode enforcement applies here too.** In `allowlist` mode, if a
+recipient's domain isn't on the allowlist, invitation falls back to
+magic-link regardless of what discovery finds. In `hybrid`/`open` mode,
+discovery is trusted per-user with rate limiting.
+
+**Existing external-invite code paths converge here.** Today's magic-link
+invitation flow (external user gets emailed a redemption link) becomes
+the "Nothing discoverable" branch. No change to the redemption side —
+still creates an `is_external=true` shadow user. New paths simply set a
+richer `federation_kind` on that same shadow user, which downstream
+enables the stronger auth channel on next login attempt.
+
+## Interactions with existing auth flow
+
+- **AUTH_METHODS** — add `federated` as a new allowlist token, analogous
+  to `oidc`. `OXICLOUD_AUTH_METHODS=password,federated` means password
+  login OR autodiscovered federated login. Same fail-fast semantics as
+  the existing OIDC token.
+- **OIDC-master rule** — `federation_kind='oidc'` OR
+  `federation_kind='indieauth'` OR `federation_kind='openid_fed'` all
+  short-circuit magic-link login for that user. Federation-authenticated
+  users authenticate through their federation. See
+  [ocm.md § Magic-link on federated addresses](./ocm.md).
+- **JIT provisioning** — same code path as current OIDC JIT-provisioning:
+  create a shadow user on first successful federated login, `is_external`
+  handling depending on whether they should get local storage
+  (`OXICLOUD_AUTH_FEDERATION_JIT_GRANTS_STORAGE=false` by default).
+- **RP-initiated logout** — reuses the existing `end_session_endpoint`
+  discovery + `id_token_hint` flow for OIDC. IndieAuth has no standard
+  logout; local session revocation only.
+- **Back-channel logout** — reuses the existing BCL endpoint; the
+  identity key is now unambiguously the `(iss, sub)` pair (fixed by the
+  federation_issuer rename planned in [ocm.md](./ocm.md)).
+
+## Phasing (rough)
+
+**Phase 0 — Prerequisite:** federation-identity schema rename (documented
+in [ocm.md § Schema rename](./ocm.md)). Land first, no matter which
+federated-login strategy comes next.
+
+**Phase 1 — WebFinger + OIDC + Dynamic Registration.** Covers the
+self-hosted OIDC mesh case. ~1-2 weeks. Highest immediate value; runs
+on top of the existing OIDC flow.
+
+**Phase 2 — Discovery UX in the login form.** Detect email vs URL,
+run discovery on submit, show progress spinner while discovering,
+graceful fallback if no signal. ~3-5 days FE.
+
+**Phase 3 — IndieAuth strategy.** Small addition once the discovery
+framework exists. ~1 week.
+
+**Phase 3b — Discovery reused at INVITE time.** The invitation flow
+runs the same probe and dispatches to OCM / OIDC / IndieAuth /
+magic-link based on preference ordering. Recipient badge in the share
+dialog shows the chosen channel. Cache table
+`auth.federated_identity_discovery`. ~5-7 days including UX.
+
+**Phase 4 — Admin panel for discovered peers.** List, revoke, force
+rebind. ~3-5 days.
+
+**Phase 5 — Trust-mode policy switches.** Config knobs +
+allowlist-mode enforcement. ~2-3 days.
+
+**Phase 6+ — OpenID Federation 1.0.** Add when trust anchor
+infrastructure matures externally or a deployment specifically needs it.
+
+## Open questions
+
+- **Federated JIT and quotas** — federated users creating drives? Or
+  strictly grant-only externals? Default to grant-only; per-domain
+  policy could allow drive creation for trusted domains only.
+- **Discovery-cache invalidation** — when an IdP rotates keys, our
+  cached JWKS goes stale within the OIDC service's TTL (already
+  handled). Discovered issuer + registered client should also expire
+  eventually; add a periodic refresh job.
+- **Multiple discovery signals on the same domain** — WebFinger says
+  IdP is X, HTML `<link>` says Y. Rule: WebFinger wins (RFC-specified
+  discovery is authoritative over convention).
+- **Rate limiting** — discovery probes are cheap but can be abused.
+  Per-caller-IP + per-target-domain rate limits.
+- **Anti-typo** — user types `alice@gogle.com`, we discover Gogle's IdP
+  and successfully register with it. That's a working federated login
+  to a lookalike domain. Mitigation: display the discovered issuer in
+  the consent screen ("You will authenticate at
+  `https://accounts.gogle.com`"). Not fixable server-side alone;
+  user-side confirmation is the last defense.
+
+## Non-goals
+
+- Persona-style browser-mediated flow (dead)
+- Verifiable credentials / SIOP v2 (too early)
+- OpenID 2.0 backwards compatibility (deprecated a decade ago)
+- Social-login integration (Facebook / GitHub / Twitter buttons) —
+  intentionally out of scope; those require explicit RP registration and
+  a per-provider adapter, not federated identity
+
+## References
+
+- WebFinger: RFC 7033
+- OIDC Discovery 1.0: <https://openid.net/specs/openid-connect-discovery-1_0.html>
+- OIDC Dynamic Client Registration: RFC 7591 + <https://openid.net/specs/openid-connect-registration-1_0.html>
+- IndieAuth: <https://indieauth.spec.indieweb.org/>
+- OpenID Federation 1.0: <https://openid.net/specs/openid-federation-1_0.html>
+- Solid-OIDC: <https://solid.github.io/solid-oidc/>
+- BrowserID postmortem: <https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers>

--- a/docs/plan/ocm.md
+++ b/docs/plan/ocm.md
@@ -441,6 +441,63 @@ churn):
 - OCM notification handler translates peer messages into local state
   transitions (create/delete grant, update state column).
 
+## Future — multi-federation per user (account linking)
+
+The current schema is strictly 1:1 — one `auth.users` row carries ONE
+`(federation_kind, federation_issuer, federation_subject)` triple.
+Scenarios where this breaks:
+
+- **Multi-IdP link** — Alice logs in via Google today, later wants to
+  also link her corporate Keycloak (same person, two auth paths).
+- **OIDC ↔ OCM identity overlap** — Bob has a local OIDC-provisioned
+  account AND colleagues share to him via OCM at
+  `bob@theircloud.example.com`. Different trust chains → two rows.
+  His "shared with me" view splits across both identities.
+- **IdP migration** — Company switches SSO issuer; the old row is
+  orphaned, new logins mint a fresh row. All grants belong to the
+  ghost.
+- **Genuine multi-account** — some IdPs let one person hold multiple
+  accounts (different `sub`). Different identities per OIDC spec —
+  CORRECTLY two users. This case wants NO merging.
+
+The interesting split: (1)-(3) benefit from merging; (4) must stay
+separate. Merging is inherently user-driven, not automatic (auto-link
+would misbehave on case 4). Ship OCM WITHOUT this and add it when a
+real user asks — every product I've seen shipped account linking as a
+distinct feature (Nextcloud, GitHub) precisely so it can have its own
+UX design.
+
+Evolution path (documented so it's not lost, NOT for OCM MVP):
+
+```sql
+CREATE TABLE auth.user_federations (
+    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id            UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    federation_kind    TEXT NOT NULL,
+    federation_issuer  TEXT NOT NULL,
+    federation_subject TEXT NOT NULL,
+    linked_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    linked_by          UUID REFERENCES auth.users(id),
+    is_primary         BOOLEAN NOT NULL DEFAULT FALSE,
+    UNIQUE (federation_kind, federation_issuer, federation_subject),
+    UNIQUE (user_id, is_primary) DEFERRABLE
+);
+```
+
+Migration: one row per existing `auth.users` with `federation_kind
+IS NOT NULL`, `is_primary=true`, `linked_by=user_id` (self-owned).
+Then drop the three columns from `auth.users` after a backward-compat
+window (view unions the two representations).
+
+Impact on existing code: anti-duplicate lookup, BCL revocation, JIT
+provisioning, lazy rebind — all move to JOINs on `user_federations`.
+The `get_user_by_federation_subject` repo method is the single
+touchpoint; downstream callers don't change.
+
+Ships when demand appears — probably alongside a "Connect another
+account" settings page. Documented here so the OCM 1:1 shape is a
+KNOWN LIMITATION, not an oversight.
+
 ## Future — merge with a generic grant-request workflow
 
 `ocm.inbound_shares.state` is a purpose-specific state machine for the

--- a/docs/plan/ocm.md
+++ b/docs/plan/ocm.md
@@ -1,0 +1,516 @@
+# Open Cloud Mesh (OCM) — Federated Sharing
+
+Federate file-sharing with Nextcloud, ownCloud, Reva/OCIS, Seafile, and any
+other OCM 1.1+ speaker. Track the design decisions here before code lands.
+
+## Identity & auth model — DECIDED
+
+OCM-federated recipients live as **shadow rows in `auth.users`** with:
+
+- `is_external = true`
+- `password_hash = NULL` (enforced by existing `users_external_no_storage`
+  CHECK constraint)
+- `email = federated-address` (e.g. `bob@nextcloud.example.com`)
+- Federation columns (see "Schema rename — PRE-REQ" below for the
+  migration path that turns today's OIDC-specific columns into these):
+  - `federation_kind ∈ {NULL, 'magic_link', 'ocm', 'oidc'}` — distinguishes
+    the trust chain that owns this identity. NULL for internal users.
+  - `federation_issuer` — **THE AUTHORITY** that mints the subject id.
+    NOT a display name. The full identity per federation kind is
+    `(federation_issuer, federation_subject)`; the issuer is what makes
+    a subject id meaningful — two different IdPs can independently mint
+    `sub=1234` for two completely different people.
+    - `oidc` — the `iss` claim from the id_token (also
+      `discovery.issuer`), e.g.
+      `https://sso.example.com/realms/main`. Immutable per
+      spec (RFC 7519 §4.1.1).
+    - `ocm` — the peer domain, e.g. `nextcloud.example.com`. The
+      peer's domain IS the authority for its federated identities in
+      OCM's model.
+    - `magic_link` — NULL (identity is the local `email`, no external
+      authority involved).
+    - **Fixes an existing bug.** Today `oidc_provider` stores the
+      human-readable `OXICLOUD_OIDC_PROVIDER_NAME` label (e.g. "SSO",
+      "MockSSO"), not the issuer URL. Consequences of the current
+      shape:
+      1. Admin renaming `OXICLOUD_OIDC_PROVIDER_NAME` silently
+         orphans every existing OIDC user — new lookups key on the
+         new label, stored rows have the old one.
+      2. BCL revocation (`revoke_user_sessions_by_oidc_subject`)
+         keys on the label; same rename → BCL notifications from the
+         IdP match no one. Silent security regression — users
+         thought-kicked stay logged in.
+      3. Multi-IdP futures (multi-realm, multi-tenant) would suffer
+         cross-issuer subject collision if two IdPs share a display
+         name.
+    - Display name becomes a separate concern — either derived from a
+      `peer_configs.issuer → display_name` lookup, or stored alongside
+      as a denormalized `federation_display_name` column (admin-
+      editable, no identity impact). Not part of the identity key.
+  - `federation_subject` — the remote id string. Stability:
+    - `oidc` — the `sub` claim, issuer-assigned, MUST NOT change per spec
+      (RFC 7519 §4.1.2, OIDC Core §5.4). Email can change on the IdP
+      side with no impact on this row.
+    - `ocm` — the full federated address (`bob@nextcloud.example.com`).
+      OCM 1.1 does NOT define a separate stable subject id; the address
+      IS the identity. If a peer renames a user, we see a new address
+      and create a new shadow row. Grants against the old row are
+      orphaned until admin intervention. This is a protocol
+      limitation — some peers ship extensions (Nextcloud Global Site
+      Selector, ScienceMesh/Reva `opaqueUserId`) but they aren't in
+      base OCM. Treat `federation_subject` as opaque; if a future OCM
+      version adds a stable id, swap the value in without schema change.
+    - `magic_link` — NULL (magic-link externals don't carry a federation
+      subject; their identity is the local `email` column).
+  - Composite UNIQUE index `(federation_kind, federation_issuer, federation_subject)`
+    WHERE `federation_kind IS NOT NULL`.
+- `storage_quota_bytes = 0`, no home folder provisioned
+
+**Grants stay `subject_type = 'user'` on `storage.role_grants`.** No new
+subject-type variant. The team's earlier refactor (2026-07-30) removing
+`'external'` from the CHECK constraint is the precedent — external is a flag
+on the user row, not a subject type.
+
+**AuthZ engine unchanged.** Middleware for OCM WebDAV resolves sharedSecret →
+`ocm.outbound_shares.recipient_user_id` (the shadow row), sets `CurrentUserId`
+to that, and the existing `authz.require(subject, resource, permission)` runs
+identically for local + federated subjects.
+
+## Schema rename — PRE-REQ (ships before ANY OCM code)
+
+Today's `auth.users.oidc_provider` / `oidc_subject` are semantically identical
+to the generic `federation_issuer` / `federation_subject` above. Keeping both
+would be drift risk. Rename first, then start OCM work on top of the clean
+shape.
+
+```sql
+ALTER TABLE auth.users RENAME COLUMN oidc_provider TO federation_issuer;
+ALTER TABLE auth.users RENAME COLUMN oidc_subject  TO federation_subject;
+ALTER TABLE auth.users ADD  COLUMN federation_kind TEXT
+    CHECK (federation_kind IN ('magic_link', 'ocm', 'oidc'));
+
+-- Backfill kind: rows that had oidc_provider set were all OIDC-linked.
+UPDATE auth.users SET federation_kind = 'oidc'
+    WHERE federation_issuer IS NOT NULL;
+
+-- Swap the anti-duplicate index.
+DROP   INDEX idx_users_oidc;
+CREATE UNIQUE INDEX idx_users_federation
+    ON auth.users(federation_kind, federation_issuer, federation_subject)
+    WHERE federation_kind IS NOT NULL;
+```
+
+**Value migration is more than a rename** — today's stored values in the
+renamed `federation_issuer` column are DISPLAY LABELS (e.g. `'MockSSO'`,
+`'MyIdP'`), not issuer URLs. Rewriting them to real issuer URLs
+touches every existing OIDC row and can't happen in one atomic step without
+losing rollback ability. Phase it:
+
+### Rename PR — Phase A (schema)
+- Add columns (`federation_kind`, `federation_issuer` renamed from
+  `oidc_provider`, `federation_subject` renamed from `oidc_subject`) —
+  the SQL block above.
+- Application code DUAL-WRITES on OIDC login: still writes the display
+  label to `federation_issuer` (unchanged semantics) AND stamps
+  `federation_kind = 'oidc'`. Reads unchanged.
+- Ships safely as a pure rename + kind-backfill. Rollback = drop the
+  `federation_kind` column; the renamed columns keep working with the
+  old code because their VALUES haven't changed.
+
+### Rename PR — Phase B (progressive lazy rebind on OIDC login)
+
+**Simplification** — no explicit backfill CLI needed. The id_token
+carries the true `iss` claim on every OIDC login, so the migration
+does itself organically:
+
+- On every successful OIDC login: if the user's stored
+  `federation_issuer` does not equal the id_token's `iss`, UPDATE it
+  (with an audit line `event="federation.issuer_rebound"`,
+  `reason="lazy_backfill"`). First login post-upgrade heals the row.
+- Users who never log in stay on the legacy label — but they also
+  can't do anything (no login → no action), so the stale value is
+  harmless. It appears only in admin listings, where a "legacy label
+  needs rebind" badge could surface if we care.
+- Contradiction guard: if the observed `iss` is DIFFERENT from the
+  stored issuer AND the stored issuer is already a valid URL (not a
+  display label), that's a genuine identity change — refuse the login
+  with an audit event and admin alert. Preserves "identity change is
+  admin-mediated." Heuristic for label vs URL: starts with `http://`
+  or `https://` and contains `/`.
+- Same lazy-rebind logic covers BCL: if a BCL notification's `iss`
+  matches a user's `federation_subject` but issuer differs, we can
+  either rebind (safer bet: same peer just told us their true issuer)
+  or refuse and audit. Recommend refuse-and-audit, since BCL is
+  server-to-server and less user-driven.
+
+**CLI subcommand shape (optional, ships later if needed)** — lives
+under `oxicloud-cli federation …` (see `src/bin/oxicloud-cli.rs` for
+the domain/action pattern; add `federation` module alongside
+`opaque`). Two subcommands worth having if operators want proactive
+control:
+
+- `federation status` — show counts of users by `federation_kind` and
+  how many still hold display-label-shaped `federation_issuer` values.
+- `federation remap-issuer --from-label X --to-issuer https://...` —
+  bulk-update the users still holding a specific legacy label, for
+  operators who want to close the migration without waiting for
+  every user to log in.
+
+**All user-identifier arguments accept EITHER username OR user UUID.**
+Not all users have a username (email-only signups per PR-18 leave it
+NULL); the CLI must handle both, resolving via
+`SELECT id FROM auth.users WHERE username = $1 OR id::text = $1`.
+Applies to any subcommand that takes a user reference.
+
+- New admin CLI or boot-time task: for each row where
+  `federation_kind = 'oidc'`, try to derive the true issuer URL:
+  - **Single-IdP deployment** (typical): if the current OIDC config's
+    `issuer_url` is set AND no other candidate exists, UPDATE all rows
+    to that issuer. One-line log per row updated.
+  - **Multi-value case** (deployment has renamed
+    `OXICLOUD_OIDC_PROVIDER_NAME` mid-life, so the same physical IdP
+    has rows with different labels): auto-backfill would smear all
+    labels into the SAME issuer — WRONG for rows that predate the
+    label swap. **Refuse to auto-backfill**; emit a boot audit warning
+    listing the distinct current values + affected user_ids; require
+    operator to pick a mapping via CLI (`oxicloud federation
+    remap-issuer --from-label X --to-issuer https://…`) or accept
+    the current-config issuer for all rows via
+    `--all-legacy-labels`.
+  - **Genuine multi-IdP** (rare today, forward-looking): fail loud;
+    no automatic mapping is safe. Manual mapping per label.
+- Log each mapping decision to `audit` for post-hoc traceability.
+- Ship after Phase A has been in production long enough to prove
+  stable (one release cycle at minimum).
+
+### Rename PR — Phase C (read switch + lazy rebind)
+- Application code reads anti-duplicate lookups AND BCL revocation
+  keying on `(federation_kind, federation_issuer, federation_subject)`.
+- On EVERY successful OIDC login: if the row's current
+  `federation_issuer` value doesn't equal the id_token's `iss` claim,
+  UPDATE it (with an audit line). This catches rows Phase B couldn't
+  resolve automatically — the first login after rollout self-heals.
+- Dual-write continues (kind + issuer both stamped from id_token now).
+- Hard failure mode to watch for: if the `iss` on the id_token
+  contradicts a Phase-B-backfilled value for existing users, we've
+  either (a) misconfigured the IdP, or (b) the IdP is a completely
+  different one than we backfilled to. Refuse the login with an audit
+  event and admin alert rather than silently rebind — preserves the
+  principle "identity change is admin-mediated".
+
+### Rename PR — Phase D (drop legacy compatibility)
+- Precondition check: no rows remain with a `federation_issuer` value
+  that looks like a display label (heuristic: doesn't start with
+  `http://` or `https://`, doesn't contain `/`).
+- Remove any dead code paths that assumed display-label semantics.
+- No column drop needed — the columns are already renamed. This phase
+  is code-only.
+- Ships when telemetry from Phase C shows zero unresolved
+  federation_issuer values across the fleet.
+
+Total: rename in one release cycle, value backfill in the next, read
+switch after that, cleanup at leisure. Each phase reversible. Operator
+warnings surface the exceptional cases (multi-label, multi-IdP) so
+they don't get silent-defaulted into a broken state.
+
+Rust-side rename (~15-20 sites, mechanical):
+- `User` entity fields (`oidc_provider` → `federation_issuer` etc.)
+- `UserPgRepository` SQL statements
+- `OidcIdClaims → User` mapping in `auth_application_service` (sets
+  `federation_kind = 'oidc'`)
+- `admin_settings_service`'s env-override table
+- Any DTOs that leaked `oidc_provider` externally — check `UserDto` before
+  the migration in case FE reads the field
+- Tests
+
+Why rename rather than coexist:
+- `oidc_provider` is a misleading name anyway — a value like
+  `MyIdP` isn't a "provider" (that's a category), it's the IdP's
+  identity/name. `federation_issuer` reads more truthfully.
+- Adding OCM alongside without renaming forces every future query that asks
+  "is this user externally-owned?" to check two column pairs. One canonical
+  shape is cheaper.
+
+The rename can ship as an independent PR before OCM work starts. Backfilling
+`kind = 'oidc'` for existing rows is monotone (no NULL flips), so the
+migration is reversible if we need to abort.
+
+## Magic-link on federated addresses — DECIDED
+
+Default: **`federation_kind='ocm'` users CANNOT use magic-link login.**
+Same rule shape as the existing OIDC-master rule
+(`feedback_oidc_master_no_magic_link_bypass`).
+
+Enforcement in `is_magic_link_login_allowed_for(&user)`:
+
+```
+if user.federation_kind == Some(FederationKind::Ocm) {
+    return false;  // audit: reason="ocm_federated"
+}
+```
+
+Rationale:
+- OCM's identity boundary is the remote peer's authentication (which may
+  enforce MFA, geo-fence, hardware keys). Magic-link would downgrade that to
+  mailbox-strength.
+- Federation revocation on the remote side (peer disables bob) should NOT
+  leave bob with a working login on our side via his mailbox.
+- Same anti-enumeration shape as `oidc_user` rejection — 404 to the caller,
+  audit line internally.
+
+### Deferred opt-in: `allow_magic_link_for_ocm_federated`
+
+Some deployments will want unified UX (federated invite doubles as a browser
+account). Ship as an additive policy on `OXICLOUD_AUTH_POLICIES`:
+
+```
+OXICLOUD_AUTH_POLICIES=allow_magic_link_for_ocm_federated
+```
+
+Same shape as `permit_magic_link_for_password_users` — off by default,
+operators who enable it accept the auth-boundary trade-off. Document alongside
+the shared-computer / weakened-boundary caveat.
+
+**Not implemented in the initial OCM ship.** Add when a deployment actually
+asks for it.
+
+## Reverse case: address already exists as magic-link external
+
+If `bob@example.com` is already in our DB as a magic-link external (a local
+user invited him last month) AND a peer sends us an OCM share addressed to
+`bob@example.com`, do NOT upgrade in place. Create a separate shadow row
+with `federation_kind='ocm'`. Different trust chains, different identities.
+The composite UNIQUE index on `(federation_kind, federation_issuer,
+federation_subject)` allows the two rows to coexist.
+
+Consequence: magic-link bob CAN log in; OCM bob CANNOT. Same address, two
+accounts, two postures. Honest about the different trust semantics.
+
+## New DB shape
+
+```
+ocm.trusted_peers   -- allowlist of federation partners
+ocm.outbound_shares -- shares WE created for remote users (with acceptance state)
+ocm.inbound_shares  -- shares OTHER servers created for our users (with acceptance state)
+ocm.notifications   -- wire-level OCM notifications (retry queue + dedup + forensic audit)
+```
+
+### `ocm.notifications` in detail
+
+**Not to be confused with acceptance state.** When a user clicks
+Accept/Decline on a pending invitation, that mutates
+`ocm.inbound_shares.state` — the user's decision lives there. This
+table stores the *wire message* we then send to the peer telling them
+"our user accepted." The two are logically distinct: acceptance is
+share-scoped workflow state, notifications are transport-layer events.
+Future readers: don't conflate.
+
+Given that, `ocm.notifications` serves FOUR overlapping purposes.
+Collapsing them into one table (instead of parallel queue / dedup /
+audit tables) avoids drift.
+
+**1. Retry queue for outbound.** OCM 1.1 requires exponential-backoff
+retry when the peer's `POST /notifications` fails. Rows with
+`direction='outbound' AND processing_result='pending' AND
+next_retry_at <= now()` are what a background worker picks up.
+
+**2. Idempotency / dedup for inbound.** Peers may resend after network
+hiccups. `UNIQUE(peer_domain, remote_notification_id)` short-circuits.
+
+**3. Debugging.** "Why did that share disappear?" — grep by
+`related_share_id`. Payload preserved verbatim as JSONB.
+
+**4. Security audit.** Federated state transitions cross trust
+boundaries; every one is auditable, joinable to peer domain + share.
+
+Sketch:
+
+```sql
+CREATE TYPE ocm.notification_direction AS ENUM ('inbound', 'outbound');
+CREATE TYPE ocm.notification_kind AS ENUM (
+    'share_accepted', 'share_declined', 'share_revoked',
+    'share_unshared', 'user_removed', 'other'
+);
+CREATE TYPE ocm.notification_result AS ENUM (
+    'pending', 'success', 'failed', 'ignored'
+);
+
+CREATE TABLE ocm.notifications (
+    id                     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    direction              ocm.notification_direction NOT NULL,
+    peer_domain            TEXT NOT NULL,
+    related_share_kind     TEXT CHECK (related_share_kind IN ('inbound','outbound')),
+    related_share_id       UUID,        -- points at inbound_shares.id OR
+                                        -- outbound_shares.id; typed union
+                                        -- isn't natural in Postgres so no
+                                        -- hard FK — verify at insert
+    kind                   ocm.notification_kind NOT NULL,
+    payload                JSONB NOT NULL,
+    remote_notification_id TEXT,
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    processed_at           TIMESTAMPTZ,
+    processing_result      ocm.notification_result NOT NULL DEFAULT 'pending',
+    attempt_count          INTEGER NOT NULL DEFAULT 0,
+    next_retry_at          TIMESTAMPTZ, -- outbound only
+    error_message          TEXT,
+    UNIQUE (peer_domain, remote_notification_id)
+);
+
+CREATE INDEX idx_ocm_notif_related
+    ON ocm.notifications(related_share_id, related_share_kind);
+CREATE INDEX idx_ocm_notif_retry
+    ON ocm.notifications(next_retry_at)
+    WHERE direction = 'outbound' AND processing_result = 'pending';
+CREATE INDEX idx_ocm_notif_peer
+    ON ocm.notifications(peer_domain, created_at DESC);
+```
+
+**Retry policy** — attempt 1 immediate; 2-5 with exponential backoff
+(30s, 2m, 10m, 1h); after attempt 5, mark `failed` and emit
+`event="ocm.notification_delivery_gave_up"` with admin alert.
+Configurable via `OXICLOUD_OCM_NOTIFICATION_MAX_ATTEMPTS` (default 5).
+
+**Retention** — 90 days default, purged by a nightly consistency-job
+handler (`notifications_cleanup`), fits the existing recovery-jobs
+pattern. `failed` rows kept indefinitely until admin resolution
+(paper trail). Configurable via
+`OXICLOUD_OCM_NOTIFICATION_RETENTION_DAYS`.
+
+**Inbound security invariants** — verify BEFORE mutating any state:
+
+- Peer domain matches the peer that owns the referenced share
+  (`peer_mismatch` → mark `ignored`, audit).
+- `related_share_id` points at an existing share in the correct table
+  (`unknown_share` → `ignored`).
+- Notification kind is compatible with current share state
+  (`state_conflict` → `ignored`, e.g. accept on an already-declined
+  share).
+
+Each rejection emits an `event="ocm.notification_rejected"` audit line
+with a stable `reason=` field (`peer_mismatch | unknown_share |
+state_conflict | duplicate`) — same anti-drift discipline as other
+structured audit events, per `feedback_enum_over_string_literals_in_logs`.
+
+Plus `auth.users` new columns above.
+
+Plus `storage.resource_kind` extension for a `RemoteShare` resource type
+(pointing at `ocm.inbound_shares.id`), so accepting an inbound share is a
+regular grant row from the accepting user to the RemoteShare resource.
+
+## Invitation workflow — where accept/decline lives
+
+Local grants have no accept/decline concept — the grant IS the access.
+OCM introduces one because the protocol is push-driven (peer POSTs a
+share, our user decides whether to surface it). Solved WITHOUT adding
+state to `role_grants`:
+
+**Inbound shares (peer → us):**
+- `POST /ocm/shares` creates an `ocm.inbound_shares` row (pending). NO
+  role_grant created yet.
+- User sees pending invitation in `/shared-with-me` → `Federated` tab
+  (new), plus a badge on AppShell.
+- **Accept** → insert `role_grants` row (subject = local user, resource
+  = a new `RemoteShareResource` entry, permission = as offered), POST
+  accept notification to peer, mark `ocm.inbound_shares.accepted_at`.
+- **Decline** → no grant created; POST decline notification, mark
+  `ocm.inbound_shares.declined_at`. Row kept for audit.
+- Modal prompt on next login if pending count changed since last login.
+
+**Outbound shares (us → peer):**
+- Grant is created immediately in `role_grants` (subject = shadow user
+  for the federated recipient). AuthZ from OUR side is active the
+  moment the OCM POST succeeds — remote user CAN consume via WebDAV.
+- `ocm.outbound_shares` tracks delivery + acceptance state
+  (`delivering | delivered | accepted | declined_by_recipient |
+  undeliverable | revoked`), surfaced in `/shared` (outgoing view) as
+  a status column.
+- Share dialog recognizes `user@remote-domain` and shows a channel
+  badge on the resolved recipient (see
+  [federated-login.md § Same discovery layer serves invitation](./federated-login.md)).
+- Peer sends decline notification → auto-revoke the local grant
+  (recipient said no, keeping access is pointless). Configurable
+  behaviour deferred.
+
+**ReBAC extensions needed** (all local to the OCM code path, no engine
+churn):
+- New `resource_type = 'remote_share'` on `role_grants`, resource_id
+  pointing to `ocm.inbound_shares.id`. AuthZ dispatches to a
+  WebDAV-proxy handler for this type.
+- `ocm.inbound_shares.state` and `ocm.outbound_shares.state` columns
+  hold acceptance metadata. `role_grants` stays state-free.
+- OCM notification handler translates peer messages into local state
+  transitions (create/delete grant, update state column).
+
+## Future — merge with a generic grant-request workflow
+
+`ocm.inbound_shares.state` is a purpose-specific state machine for the
+MVP. If OxiCloud later gains a local pending-approval workflow (Alice
+asks Bob for Read on his folder; Bob approves) — a real
+enterprise-features ask — the natural refactor is to extract a shared
+workflow spine:
+
+- New table `storage.grant_requests` with
+  `(subject, resource, requested_permission, approval_authority, state,
+  decided_at, decided_by)`. Approval_authority distinguishes who holds
+  decide-power: `owner` (local approval), `recipient` (OCM inbound
+  accept, magic-link redeem), `admin` (policy gate).
+- `ocm.inbound_shares` keeps its federation-specific columns
+  (peer_domain, remote WebDAV URL, sharedSecret) and gains a
+  `grant_request_id` FK. Accept = flip request to `approved` + create
+  `role_grant`. Decline = flip to `rejected`.
+- `magic_link_tokens` with `resource_kind ≠ NULL` (invitation-purpose
+  tokens) gets the same FK. Redeem = flip to `approved` + create
+  `role_grant`.
+- **`role_grants` stays approved-only.** Hot AuthZ path doesn't gain a
+  state filter — no regression on read paths.
+
+**NOT** a merge of the tables themselves — collapsing OCM /
+magic-link / local-request into `role_grants` with a state column
+would leak state-machine logic into every AuthZ check. The merge is at
+the ABSTRACTION level: three flavors of "prospective grant" today
+(magic-link invite, OCM inbound, hypothetical local request) share ONE
+workflow table; channel-specific data stays in satellites.
+
+Migration is additive and non-breaking: add tables + FK columns,
+backfill existing rows as synthetic `approved` requests for audit
+continuity, refactor callers one at a time. No ReBAC engine change.
+
+Not urgent — the OCM MVP works fine without it. Recorded so the
+option isn't forgotten if local approval workflow ever gets requested.
+
+## Phasing (rough)
+
+1. **Phase 0** — Discovery (`/ocm-provider`) + inbound receive + FE listing
+   of received shares (metadata only, no consumption yet). ~1 week.
+2. **Phase 1** — Consume remote shares (server-side WebDAV proxy). ~1-2 weeks.
+   Needs a WebDAV client — none exists in the tree today.
+3. **Phase 2** — Outbound sharing (share dialog recognizes `user@remote`).
+   ~3-5 days.
+4. **Phase 3** — OCM 2.0 invite handshake (ScienceMesh trust flow). ~1 week.
+5. **Phase 4** — Address book / federated-contact registry. ~1 week.
+
+## Open design questions (not yet decided)
+
+- **Trust model** — open federation vs allowlisted peers? Recommend
+  allowlist-by-default (safer for self-hosted).
+- **Recipient resolution rule** — `username@LOCAL_DOMAIN` vs `email` match?
+  Recommend username-based (matches Nextcloud, deterministic).
+- **Quota accounting** — do consumed remote shares count against the
+  recipient's `storage_quota_bytes`? Recommend no (remote storage is remote).
+- **Notification authenticity** — bind every OCM notification to its
+  `inbound_share.id`, refuse if peer domain doesn't match the domain we
+  recorded at share creation.
+- **Group grants** — local group containing OCM-federated user is weird.
+  Semantically fine but the share dialog should probably discourage it.
+
+## Interop targets
+
+- Nextcloud in Docker as the primary peer (both directions).
+- OCIS/Reva as the CS3-blessed reference behaviour.
+- SciMesh integration tests once Phase 3 is in.
+
+## References
+
+- OCM 1.1 spec: <https://cs3org.github.io/OCM-API/>
+- Nextcloud OCM docs (implementation quirks): <https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/federated_cloud_sharing.html>
+- Reva (Go reference impl): <https://github.com/cs3org/reva>

--- a/docs/plan/oidc-account-linking.md
+++ b/docs/plan/oidc-account-linking.md
@@ -1,0 +1,337 @@
+# OIDC Account Linking — Self-Service Link / Unlink
+
+Logged-in local users self-serve the wiring of an OIDC identity to their
+account (no admin round-trip / manual SQL). Companion: unlink for users
+who want to detach the OIDC identity while keeping their local login.
+
+Design context: builds on the federation-identity rename
+([ocm.md § Schema rename](./ocm.md)) — a linked identity is
+`(federation_kind='oidc', federation_issuer=<iss URL>, federation_subject=<sub>)`
+on `auth.users`.
+
+## UX flow — auto-link on first OIDC login (majority case)
+
+Handles the case where a user already has a local OxiCloud account and
+tries "Sign in with SSO" (or is auto-redirected under the standalone-OIDC
+policy) for the first time. Without auto-link, today's flow refuses with
+"A user with email X already exists — contact admin to link your OIDC
+identity" — forcing an admin round-trip or the self-service link flow
+below. Auto-link removes that friction for the common case:
+
+**Trigger:** OIDC login callback lookup misses on `(iss, sub)` AND on
+the legacy-label fallback (Phase B), but the IdP-returned email matches
+an existing OxiCloud user.
+
+**Decision tree** (all checks under normalized-email comparison):
+
+```
+Look up user by normalize(claims.email):
+  ├─ exactly 1 match + email_verified=true + user not already linked
+  │    → AUTO-LINK: UPDATE federation_kind='oidc', issuer=iss, subject=sub
+  │    → emit `federation.auto_linked` audit event
+  │    → proceed with login as this user
+  ├─ 1 match + email_verified=false
+  │    → refuse (`auto_link_email_not_verified`)
+  ├─ 1 match + already linked to a DIFFERENT identity
+  │    → refuse (`already_linked_elsewhere`)
+  ├─ >1 match (ambiguous under +alias normalization)
+  │    → refuse (`email_ambiguous`)
+  └─ 0 matches
+       → existing JIT-provisioning branch (creates a fresh user)
+```
+
+**Refusals fall through to the current "contact admin" error page**
+(same shape as before this feature). Users can then self-serve via the
+link flow below, or the admin can intervene.
+
+### Security model — why auto-link is safe here
+
+The classic account-takeover attack: attacker creates a rogue IdP
+account with the victim's email → OIDC login → auto-link → hijacks the
+victim's OxiCloud account.
+
+Mitigation is the industry-standard **`email_verified=true` gate**: the
+IdP itself has verified the user controls the email, so the attacker
+can't just claim any email in their own IdP account.
+
+Safe in OxiCloud's current single-IdP model because:
+- Admin explicitly configures ONE trusted IdP (`OXICLOUD_OIDC_ISSUER_URL`)
+- Same trust chain as JIT auto-provisioning today (which we already
+  gate on `email_verified` when `OXICLOUD_REQUIRE_VERIFIED_EMAIL=true`)
+- The IdP is chosen by the admin, not the user
+
+**Explicitly NOT safe** for the future multi-IdP federated login
+(`docs/plan/federated-login.md` — any WebFinger-discovered IdP is
+accepted). That flow needs different rules: allowlisted-IdP-only
+auto-link, or no auto-link at all. Deferred until that lands.
+
+### Config knob
+
+```
+OXICLOUD_OIDC_AUTO_LINK_EMAIL_MATCH=true   # default TRUE
+```
+
+Ships enabled — it's the good UX. Admins with compliance requirements
+that mandate explicit consent for every link opt out. `false` restores
+the "refuse with contact admin" behavior; self-service link flow (below)
+remains available.
+
+Documented as a deployment-config knob in **THREE places** — all must
+be updated when this env var lands (per the project convention that
+every env var appears in every config-reference surface):
+
+- `example.env` — commented entry under the OIDC block with the
+  default value + one-sentence explanation
+- `docs/config/env.md` — table row in the OIDC section
+- `docs/config/oidc.md` — narrative paragraph explaining the
+  auto-link decision tree and security model (short form of the
+  section above)
+
+## UX flow — link
+
+1. User logged in via password/OPAQUE lands on `/profile`
+2. Sees a **"Connect Single Sign-On"** card, visible when
+   `oidc.enabled && !user.federation_kind`
+3. Clicks button → SPA `POST /api/auth/oidc/link/start` (authenticated)
+   → backend mints a state token, stores a `pending_oidc_flow` entry with
+   `intent = Link { user_id }`, returns `{ authorize_url }`
+4. Full-page navigation to the IdP → user authenticates as themselves
+5. IdP redirects back to `/api/auth/oidc/callback?code=&state=`
+6. Callback recognises the `Link` intent (via state cache lookup) →
+   exchanges code → validates id_token → runs safety checks (below) →
+   UPDATE user row
+7. Redirect to `/profile?linked=1` — SPA shows a toast and strips the
+   query param
+
+## UX flow — unlink
+
+1. User (currently OIDC-linked AND with alternative auth wired) sees a
+   **"Disconnect Single Sign-On"** card on `/profile`
+2. Clicks button → SPA `POST /api/auth/oidc/unlink`
+3. Backend refuses if the user has no other auth method (see below)
+4. On success: profile refreshes, `federation_kind`/`issuer`/`subject`
+   become `null`, "Connect SSO" card takes over the space
+
+## Safety checks — link callback
+
+Ran BEFORE the UPDATE. Any refusal returns
+`/profile?link_error=<stable-key>` with the reason logged internally.
+
+| Check | Refuse reason | Rationale |
+|---|---|---|
+| Session valid (state's `user_id` matches an active session) | `session_expired` | Cookie invalidated during the IdP round-trip; treat as auth failure |
+| IdP-returned email matches OxiCloud email after normalization | `email_mismatch` | Prevents "link Bob's identity to my account, then Bob logs in via OIDC and lands here" |
+| IdP provided an email at all | `email_not_provided` | Without email we can't verify identity ownership — refuse |
+| Identity `(kind, iss, sub)` not already linked to a DIFFERENT user | `already_linked_elsewhere` | Prevents linking the same OIDC identity to two OxiCloud accounts |
+| Current user isn't linked to a DIFFERENT identity | `already_linked` | User must unlink first — no silent identity swap |
+| Same identity as currently-linked → idempotent success | (no error) | Repeat link is a no-op success |
+
+Optional deferred: step-up auth (require fresh password/OPAQUE
+verification within the last N minutes before starting link). Guards
+against session-theft → link-attack. Add if we care.
+
+## Email normalization
+
+`common::text::normalize_email_for_link`:
+
+```rust
+pub fn normalize_email_for_link(email: &str) -> String {
+    let lower = email.trim().to_ascii_lowercase();
+    let Some((local, domain)) = lower.split_once('@') else {
+        return lower;
+    };
+    // Strip +alias sub-addressing (Gmail / Outlook / Fastmail / etc.):
+    // alice+github@example.com → alice@example.com
+    let local_base = local.split_once('+').map(|(b, _)| b).unwrap_or(local);
+    format!("{}@{}", local_base, domain)
+}
+```
+
+**NOT** doing dot-stripping (Gmail-only, causes false positives on other
+providers). NOT doing Unicode normalization (email addresses compare as
+ASCII-normalized already).
+
+Behavior matrix:
+
+| OxiCloud email | IdP email | Match? |
+|---|---|---|
+| `alice@example.com` | `alice@example.com` | ✅ |
+| `alice@example.com` | `Alice@example.com` | ✅ (case) |
+| `alice@example.com` | `alice+oidc@example.com` | ✅ (alias) |
+| `alice+work@example.com` | `alice@example.com` | ✅ (alias both) |
+| `alice@example.com` | `bob@example.com` | ❌ |
+| `alice@example.com` | (missing) | ❌ (`email_not_provided`) |
+
+Legitimate-but-refused cases (documented, admin unlinks+relinks):
+- User changed email on IdP but not on OxiCloud
+- User's IdP email uses a different domain than OxiCloud email
+
+## Unlink refusal — retain a working direct login
+
+`POST /api/auth/oidc/unlink` refuses when the user has **no other
+credential** to log in with:
+
+```
+if !user.has_password() && !user.opaque_registered() {
+    return AccessDenied("cannot_unlink_no_alternative_auth");
+}
+```
+
+Rationale: OIDC-only account unlinking creates a passwordless account
+with no OIDC either → the user can't log in AT ALL. Magic-link isn't a
+safe fallback since (a) it's gated by SMTP wiring and (b) the
+OIDC-master rule wouldn't refuse it AFTER unlink but does BEFORE, so
+users could be surprised by inconsistent behavior. Refusing at the API
+layer forces the user to add a password first (via profile change-
+password card) before unlinking.
+
+`opaque_registered` counts as an alternative because an OPAQUE envelope
+IS a login credential.
+
+## Wire changes — endpoints
+
+| Method | Path | Auth | Body | Returns |
+|---|---|---|---|---|
+| `POST` | `/api/auth/oidc/link/start` | Bearer/cookie | `{}` | `{ authorize_url: "..." }` |
+| `POST` | `/api/auth/oidc/unlink` | Bearer/cookie | `{}` | `200 OK` or `403` |
+| `GET` | `/api/auth/oidc/callback` | Public | — | Extended: `?intent=link` cases redirect to `/profile?...` |
+
+## Pending-flow cache extension
+
+Existing `AuthApplicationService::pending_oidc_flows: Cache<String, PendingOidcFlow>`
+gains an `intent` field:
+
+```rust
+enum FlowIntent {
+    Login,
+    Link { user_id: Uuid },
+}
+
+struct PendingOidcFlow {
+    pkce_verifier: String,
+    nonce: String,
+    nc_flow_token: Option<String>,
+    intent: FlowIntent,
+}
+```
+
+Default `Login` preserves existing behavior. `Link` is set by
+`prepare_oidc_link(user_id)`. The callback dispatches on the intent
+variant.
+
+## Repo methods
+
+```rust
+async fn link_federation_identity(
+    &self, user_id: Uuid,
+    kind: &str, issuer: &str, subject: &str,
+) -> Result<(), UserRepositoryError>;
+// Returns AlreadyExists on UNIQUE(kind, issuer, subject) violation —
+// app service translates to `already_linked_elsewhere`.
+
+async fn unlink_federation_identity(
+    &self, user_id: Uuid,
+) -> Result<(), UserRepositoryError>;
+// UPDATE ... SET federation_kind = NULL, federation_issuer = NULL,
+// federation_subject = NULL WHERE id = $1.
+```
+
+## Audit events
+
+- `federation.link_started` — user_id, intent (self-service flow only)
+- `federation.link_completed` — user_id, kind, issuer, subject
+- `federation.link_refused` — user_id, reason (stable enum-shaped key:
+  `session_expired`, `email_mismatch`, `email_not_provided`,
+  `already_linked_elsewhere`, `already_linked`)
+- `federation.auto_linked` — user_id, kind, issuer, subject,
+  reason=`email_match_verified` (fired by the auto-link branch on the
+  OIDC callback path — NOT by the self-service link flow)
+- `federation.auto_link_refused` — user_id (if resolvable), reason
+  (`auto_link_disabled`, `auto_link_email_not_verified`,
+  `email_ambiguous`, `already_linked_elsewhere`)
+- `federation.unlinked` — user_id
+- `federation.unlink_refused` — user_id, reason (=`no_alternative_auth`)
+
+Same anti-drift discipline as other structured audit events (per
+`feedback_enum_over_string_literals_in_logs`).
+
+## Hurl test coverage
+
+`tests/oidc/link_unlink.hurl` under the OIDC runner:
+
+**Auto-link scenarios** (OIDC login path with email match):
+
+1. **Auto-link happy path** — Alice has a local account
+   `alice@example.com`; the fake IdP is set to return that email with
+   `email_verified=true`; Alice clicks "Sign in with SSO" → login
+   completes → GET `/api/auth/me` shows `federation_kind = "oidc"` +
+   correct issuer/subject. Audit line
+   `event="federation.auto_linked", reason="email_match_verified"`
+   emitted.
+2. **Auto-link refused — email_verified=false** — fake IdP returns
+   the matching email but with `email_verified=false`; login refuses
+   with `auto_link_email_not_verified`.
+3. **Auto-link refused — normalized email ambiguity** — two OxiCloud
+   users exist (`alice@example.com` AND `alice+work@example.com`);
+   fake IdP returns `alice@example.com`; both normalize to the same
+   value; login refuses with `email_ambiguous`.
+4. **Auto-link disabled by config** — separate suite with
+   `OXICLOUD_OIDC_AUTO_LINK_EMAIL_MATCH=false`; email match no longer
+   auto-links; existing "contact admin" refusal returns. (Optional
+   Phase-2 test — env-var flip requires a separate server boot.)
+
+**Self-service link scenarios** (`POST /link/start` from an
+authenticated session):
+
+5. **Self-service happy path** — Alice logs in via password, POSTs
+   `/link/start`, follows the authorize URL, IdP returns matching
+   email, callback completes link, redirect to `/profile?linked=1`.
+6. **Email mismatch refuse** — Alice starts link, `/control/set-email`
+   on the fake IdP flips to `bob@example.com`; callback refuses,
+   redirects to `/profile?link_error=email_mismatch`.
+7. **+alias normalization link** — Alice's OxiCloud email is
+   `alice@example.com`, fake IdP returns `alice+oidc@example.com` —
+   link succeeds (both normalize to `alice@example.com`).
+8. **Already linked elsewhere** — Alice links; Bob logs in and starts
+   link; fake IdP returns Alice's identity (same sub); refused with
+   `already_linked_elsewhere`.
+
+**Unlink scenarios:**
+
+9. **Unlink success** — Alice (linked via any prior scenario) POSTs
+   `/unlink`; refresh shows `federation_kind = null`; Alice can still
+   log in via password.
+10. **Unlink refused** — a user with only OIDC (no password, no
+    OPAQUE) tries to unlink; refused with `no_alternative_auth`.
+
+## FE changes
+
+`frontend/src/routes/profile/+page.svelte`:
+
+- Import `getOidcProviders` (existing) to know if OIDC is enabled AND
+  to resolve the display name.
+- "Connect Single Sign-On" card: visible when
+  `providers.enabled && !user.federation_kind`. Button → POST
+  `/api/auth/oidc/link/start` → `window.location.assign(response.authorize_url)`.
+- "Disconnect Single Sign-On" card: visible when
+  `user.federation_kind === 'oidc' && (has_password || opaque_registered)`.
+  Button → POST `/api/auth/oidc/unlink` → refresh session.
+- On mount: read `?linked=1` → success toast; read `?link_error=<key>` →
+  error toast with localized message per key; strip query params via
+  `history.replaceState`.
+
+## Scope / non-scope
+
+**In scope for the first ship:**
+- Link + unlink endpoints + safety checks
+- Email normalization + tests
+- Hurl coverage for 6 scenarios
+- Profile-page UI
+
+**Deferred:**
+- Step-up auth before link start
+- Admin-mediated link/unlink via `oxicloud-cli federation` (proper for
+  "user changed IdP email" recovery scenario)
+- OCM link (same shape, different kind)
+- Multi-federation (multiple linked identities per user — see
+  ocm.md § Future — multi-federation per user)

--- a/example.env
+++ b/example.env
@@ -608,6 +608,17 @@ OXICLOUD_OIDC_ENABLED=false
 # Auto-create users on first OIDC login (JIT provisioning) (default: true)
 #OXICLOUD_OIDC_AUTO_PROVISION=true
 
+# Auto-link an existing local user to their OIDC identity when the
+# subject-lookup misses BUT the IdP-returned email (verified=true)
+# matches a local account. Great UX for users who already had a
+# password account when SSO gets enabled — first "Sign in with SSO"
+# just works, no admin round-trip. Requires email_verified=true from
+# the IdP; refuses on ambiguity (>1 local user normalises to the same
+# email) and when the matched user is already linked to a different
+# identity. See docs/plan/oidc-account-linking.md for the full
+# decision tree. Default: true.
+#OXICLOUD_OIDC_AUTO_LINK_EMAIL_MATCH=true
+
 # Comma-separated list of OIDC groups that grant admin role
 # Example: admins,cloud-admins
 #OXICLOUD_OIDC_ADMIN_GROUPS=

--- a/examples/bench_round20_micro.rs
+++ b/examples/bench_round20_micro.rs
@@ -255,7 +255,7 @@ struct BenchUserDto {
     id: String,
     username: Option<String>,
     email: String,
-    auth_provider: String,
+    federation_issuer: String,
     image: Option<String>,
     can_edit_image: bool,
     given_name: Option<String>,
@@ -271,7 +271,7 @@ fn a2_before(user: &BenchUser) -> BenchUserDto {
         id: user.id.to_string(),
         username: user.username.as_deref().map(str::to_string),
         email: user.email.clone(),
-        auth_provider: user.oidc_provider.as_deref().unwrap_or("local").to_string(),
+        federation_issuer: user.oidc_provider.as_deref().unwrap_or("local").to_string(),
         image: user.image.as_deref().map(|s| s.to_string()),
         can_edit_image: user.oidc_provider.is_none(),
         given_name: user.given_name.as_deref().map(str::to_string),
@@ -288,7 +288,7 @@ fn a2_after(user: BenchUser) -> BenchUserDto {
         id: user.id.to_string(),
         username: user.username,
         email: user.email,
-        auth_provider: user.oidc_provider.unwrap_or_else(|| "local".to_string()),
+        federation_issuer: user.oidc_provider.unwrap_or_else(|| "local".to_string()),
         image: user.image,
         can_edit_image,
         given_name: user.given_name,
@@ -321,7 +321,7 @@ fn section_a2() {
     let a = a2_after(user.clone());
     assert_eq!(b.image, a.image, "A2 image differs");
     assert_eq!(b.email, a.email, "A2 email differs");
-    assert_eq!(b.auth_provider, a.auth_provider, "A2 auth_provider differs");
+    assert_eq!(b.federation_issuer, a.federation_issuer, "A2 federation_issuer differs");
     assert_eq!(
         b.can_edit_image, a.can_edit_image,
         "A2 can_edit_image differs"

--- a/examples/bench_round20_micro.rs
+++ b/examples/bench_round20_micro.rs
@@ -321,7 +321,10 @@ fn section_a2() {
     let a = a2_after(user.clone());
     assert_eq!(b.image, a.image, "A2 image differs");
     assert_eq!(b.email, a.email, "A2 email differs");
-    assert_eq!(b.federation_issuer, a.federation_issuer, "A2 federation_issuer differs");
+    assert_eq!(
+        b.federation_issuer, a.federation_issuer,
+        "A2 federation_issuer differs"
+    );
     assert_eq!(
         b.can_edit_image, a.can_edit_image,
         "A2 can_edit_image differs"

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -159,7 +159,13 @@ export function createApiFetch(deps: ApiClientDeps): FetchFn {
 
 		const refreshed = await refresh();
 		if (!refreshed) {
-			onSessionExpired();
+			// Suppress the session-expired divert while a logout POST
+			// is in flight — see `logoutInProgress` above. Without this
+			// gate the ambient 401 race cancels the pending logout and
+			// swallows its `post_logout_url` response body.
+			if (!logoutInProgress) {
+				onSessionExpired();
+			}
 			throw new Error('Session expired');
 		}
 		const retryResponse = await rawFetch(input, init);
@@ -181,6 +187,24 @@ let sessionExpiredHandler: () => void = () => {
 /** Wire the real session-expired behaviour (clear store + redirect) at startup. */
 export function setSessionExpiredHandler(fn: () => void): void {
 	sessionExpiredHandler = fn;
+}
+
+// Logout-in-progress gate. Set to true by the logout endpoint wrapper
+// (endpoints/auth.ts) for the duration of the POST /api/auth/logout
+// call; reset in its `finally`. While set, `sessionExpiredHandler`
+// is suppressed — an ambient 401 during the logout window is expected
+// (the backend clears cookies and revokes the session as part of the
+// logout response, so any in-flight fetch racing the logout will 401),
+// and firing the handler would navigate to `/login?source=session_expired`
+// mid-flight, cancelling the logout POST before we get its response
+// body. Since the response body carries `post_logout_url` (the IdP's
+// end_session_endpoint URL for OIDC-linked sessions), losing it means
+// the browser never redirects to the IdP and the SSO session persists.
+// See AppShell.svelte::onLogout for the caller-side counterpart.
+let logoutInProgress = false;
+
+export function setLogoutInProgress(value: boolean): void {
+	logoutInProgress = value;
 }
 
 // Same shape as `sessionExpiredHandler` — mutable so the app can install

--- a/frontend/src/lib/api/endpoints/auth.ts
+++ b/frontend/src/lib/api/endpoints/auth.ts
@@ -379,6 +379,51 @@ export interface LogoutResult {
 	postLogoutUrl?: string;
 }
 
+/**
+ * Start the self-service OIDC linking flow. Returns the authorize URL
+ * the caller should full-page navigate to (`window.location.assign`).
+ * The IdP round-trip lands on `/api/auth/oidc/callback` which
+ * dispatches to the link branch and redirects to
+ * `/profile?linked=1` (success) or `/profile?link_error=<reason>`
+ * (safety-check refusal). See docs/plan/oidc-account-linking.md.
+ */
+export async function startOidcLink(): Promise<string> {
+	const res = await apiFetch('/api/auth/oidc/link/start', {
+		method: 'POST',
+		credentials: 'same-origin',
+		headers: { ...JSON_HEADERS, ...getCsrfHeaders() },
+		body: '{}'
+	});
+	if (!res.ok) {
+		const { errorType, message } = await parseErrorBody(res);
+		throw new ApiError(res.status, res.statusText, '/api/auth/oidc/link/start', errorType, message);
+	}
+	const body = (await res.json()) as { authorize_url?: string };
+	if (typeof body.authorize_url !== 'string' || body.authorize_url.length === 0) {
+		throw new Error('malformed link/start response: missing authorize_url');
+	}
+	return body.authorize_url;
+}
+
+/**
+ * Detach the currently-authenticated user's OIDC identity. Refuses
+ * (403 with `error_type: "AccessDenied"`) when the user has no other
+ * credential (password / OPAQUE) and would be locked out. Callers
+ * should offer the "set a password first" affordance in that case.
+ */
+export async function unlinkOidc(): Promise<void> {
+	const res = await apiFetch('/api/auth/oidc/unlink', {
+		method: 'POST',
+		credentials: 'same-origin',
+		headers: { ...JSON_HEADERS, ...getCsrfHeaders() },
+		body: '{}'
+	});
+	if (!res.ok) {
+		const { errorType, message } = await parseErrorBody(res);
+		throw new ApiError(res.status, res.statusText, '/api/auth/oidc/unlink', errorType, message);
+	}
+}
+
 export async function logout(): Promise<LogoutResult> {
 	const res = await apiFetch('/api/auth/logout', {
 		method: 'POST',

--- a/frontend/src/lib/api/endpoints/auth.ts
+++ b/frontend/src/lib/api/endpoints/auth.ts
@@ -3,7 +3,7 @@
  * primitives here intentionally bypass it (see client.ts) so a 401 surfaces as
  * a genuine failure to the caller.
  */
-import { ApiError, apiFetch } from '$lib/api/client';
+import { ApiError, apiFetch, setLogoutInProgress } from '$lib/api/client';
 import { getCsrfHeaders } from '$lib/api/csrf';
 import type { AuthResponse, User } from '$lib/api/types';
 
@@ -425,17 +425,32 @@ export async function unlinkOidc(): Promise<void> {
 }
 
 export async function logout(): Promise<LogoutResult> {
-	const res = await apiFetch('/api/auth/logout', {
-		method: 'POST',
-		credentials: 'same-origin',
-		headers: { ...JSON_HEADERS, ...getCsrfHeaders() },
-		body: '{}'
-	});
-	if (!res.ok) return {};
+	// Gate the session-expired handler for the duration of this call.
+	// The backend revokes the session + clears cookies as part of the
+	// logout response, so any in-flight fetch racing us will 401. Without
+	// the gate, that ambient 401 would trigger a navigation to
+	// `/login?source=session_expired`, cancel the pending logout POST,
+	// and swallow the `post_logout_url` response body — leaving the SSO
+	// session live on the IdP because we never navigate to its
+	// end_session_endpoint. See client.ts `logoutInProgress` for details.
+	setLogoutInProgress(true);
 	try {
-		const body = (await res.json()) as { post_logout_url?: unknown };
-		return typeof body?.post_logout_url === 'string' ? { postLogoutUrl: body.post_logout_url } : {};
-	} catch {
-		return {};
+		const res = await apiFetch('/api/auth/logout', {
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: { ...JSON_HEADERS, ...getCsrfHeaders() },
+			body: '{}'
+		});
+		if (!res.ok) return {};
+		try {
+			const body = (await res.json()) as { post_logout_url?: unknown };
+			return typeof body?.post_logout_url === 'string'
+				? { postLogoutUrl: body.post_logout_url }
+				: {};
+		} catch {
+			return {};
+		}
+	} finally {
+		setLogoutInProgress(false);
 	}
 }

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -191,7 +191,24 @@ export interface User {
 	updated_at: string;
 	last_login_at?: string | null;
 	active: boolean;
-	auth_provider: string;
+	/**
+	 * Which trust chain minted this user's federation identity. `null`
+	 * (omitted from wire) for local users (password / OPAQUE only).
+	 * `"oidc" | "ocm" | "magic_link"` for federated users. Predicate:
+	 * `!user.federation_kind` = local; `user.federation_kind === 'oidc'`
+	 * = OIDC user. Mirrors `auth.users.federation_kind` verbatim.
+	 */
+	federation_kind?: 'oidc' | 'ocm' | 'magic_link';
+	/**
+	 * Authority that minted this user's OIDC/OCM identity — issuer URL
+	 * for OIDC (id_token `iss`), peer domain for OCM. `null` (omitted)
+	 * for local users. FE that wants a friendly display label maps this
+	 * against `OidcProviders.issuer → provider_name` when they match;
+	 * shows the raw value otherwise. Renamed from the historical
+	 * `auth_provider` (which held a display label pre-Phase-B and a
+	 * `"local"` sentinel for non-federated users — both are gone).
+	 */
+	federation_issuer?: string;
 	image?: string | null;
 	can_edit_image: boolean;
 	is_external: boolean;
@@ -229,13 +246,14 @@ export interface User {
 	force_password_change?: boolean;
 	/**
 	 * TRUE when the account has a local Argon2id `password_hash` on
-	 * file. Distinct from `auth_provider`: an SSO-linked account can
-	 * ALSO carry a local password (hybrid posture — SSO for daily
-	 * login, local password as fallback). The profile page's
-	 * change-password card gates on this flag rather than on
-	 * `auth_provider === 'local'` so hybrid users can rotate their
-	 * local credential. Optional on the wire for older-backend
-	 * compatibility; missing → `false` (safe default: hide the card).
+	 * file. Distinct from `federation_kind`: an OIDC-linked account
+	 * (`federation_kind === 'oidc'`) can ALSO carry a local password
+	 * (hybrid posture — SSO for daily login, local password as
+	 * fallback). The profile page's change-password card gates on this
+	 * flag rather than on the federation shape so hybrid users can
+	 * rotate their local credential. Optional on the wire for older-
+	 * backend compatibility; missing → `false` (safe default: hide the
+	 * card).
 	 */
 	has_password?: boolean;
 }
@@ -260,15 +278,16 @@ export type AdminUserSummary = Pick<
 	| 'storage_used_bytes'
 	| 'last_login_at'
 	| 'active'
-	| 'auth_provider'
+	| 'federation_kind'
+	| 'federation_issuer'
 	| 'is_external'
 > & {
 	/** TRUE = user has a server-verifiable password on file (legacy or
-	 * admin-set). Combined with `opaque_registered` and `auth_provider`,
+	 * admin-set). Combined with `opaque_registered` and `federation_kind`,
 	 * the admin table derives the full auth capability set — a user with
 	 * `has_password=false`, `opaque_registered=false` AND
-	 * `auth_provider === 'local'` is passwordless (magic-link only,
-	 * which is the default for externals). */
+	 * `federation_kind === undefined` (no federation) is passwordless
+	 * (magic-link only, which is the default for externals). */
 	has_password?: boolean;
 	/** TRUE = user has an OPAQUE envelope on file (Phase 2 silent migration
 	 * succeeded, or the user completed a manual re-registration). */

--- a/frontend/src/routes/admin/[[tab]]/+page.svelte
+++ b/frontend/src/routes/admin/[[tab]]/+page.svelte
@@ -938,7 +938,7 @@
 	}
 	/** OIDC/SSO-provisioned account (no local password to reset). */
 	function isOidcUser(u: AdminUserSummary): boolean {
-		return !!u.auth_provider && u.auth_provider !== 'local';
+		return u.federation_kind === 'oidc';
 	}
 	/** Used-quota percentage (0 when unlimited) for the per-user progress bar. */
 	function quotaPct(u: AdminUserSummary): number {
@@ -2667,7 +2667,7 @@
 									Auth-capability chip set — ADMIN-ONLY (fields
 									scoped to `AdminUserSummaryDto`; never on
 									`UserDto`). Any user carries ZERO OR MORE of:
-									  * SSO/OIDC — `auth_provider !== 'local'`,
+									  * SSO/OIDC — `federation_kind === 'oidc'`,
 									    identity delegated to the IdP; label is
 									    the provider name.
 									  * password — `has_password` — server has a
@@ -2684,9 +2684,9 @@
 									    awaiting their welcome magic-link.
 								-->
 								{#if isOidcUser(u)}
-									<span class="badge badge--oidc" title={u.auth_provider}>
+									<span class="badge badge--oidc" title={u.federation_issuer}>
 										<Icon name="key" />
-										<span class="badge__label">{u.auth_provider}</span>
+										<span class="badge__label">{u.federation_issuer}</span>
 									</span>
 								{/if}
 								{#if u.has_password}

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -97,6 +97,13 @@
 	// immediately after so revisits / manual logouts don't re-show
 	// the stale message.
 	let sessionExpiredNotice = $state(false);
+	// One-shot notice populated from ?login_error=<key> on mount.
+	// Set by the OIDC callback's AutoLinkRefused redirect when the
+	// IdP-returned email matches an existing local account but the
+	// auto-link decision tree refused (verified=false, disabled by
+	// config, or the local account is already linked to a different
+	// identity). See docs/plan/oidc-account-linking.md § Auto-link.
+	let loginErrorNotice = $state<string | null>(null);
 	// Refs used by the mode-driven auto-focus effect. Bound with
 	// `bind:this` on the first input of each mode's form so the effect
 	// can focus the "primary" field each time the mode changes without
@@ -290,6 +297,43 @@
 		}
 	}
 
+	// Reason keys mirror the OIDC callback's redirect arms in
+	// auth_handler.rs — snake_case, matching the URL param shape used
+	// by the sibling /profile?link_error=<reason> flow. Any unknown
+	// key falls back to the generic copy so a new backend reason never
+	// blanks out the notice.
+	function loginErrorMessage(key: string): string {
+		switch (key) {
+			case 'auto_link_disabled':
+				return t(
+					'auth.login_error_auto_link_disabled',
+					'This server does not auto-link SSO accounts. Sign in with your existing credentials, then connect SSO from your profile.'
+				);
+			case 'auto_link_email_not_verified':
+				return t(
+					'auth.login_error_auto_link_email_not_verified',
+					'Your SSO provider did not confirm your email address. Verify your email at your identity provider, then try again.'
+				);
+			case 'already_linked_elsewhere':
+				return t(
+					'auth.login_error_already_linked_elsewhere',
+					'A local account with this email already exists and is linked to a different SSO identity. Contact your administrator.'
+				);
+			case 'callback_denied':
+				return t(
+					'auth.login_error_callback_denied',
+					'Your sign-in link expired or was already used. Please try signing in again.'
+				);
+			case 'callback_failed':
+				return t(
+					'auth.login_error_callback_failed',
+					"SSO sign-in couldn't complete. Please try again."
+				);
+			default:
+				return t('auth.login_error_generic', 'SSO sign-in was refused. Please try again.');
+		}
+	}
+
 	onMount(async () => {
 		// 0) Consume the one-shot `?source=session_expired` flag, if any.
 		//    Strip it from the URL so the banner never re-appears on
@@ -299,6 +343,22 @@
 			sessionExpiredNotice = true;
 			const stripped = new URL(page.url);
 			stripped.searchParams.delete('source');
+			window.history.replaceState(
+				window.history.state,
+				'',
+				stripped.pathname + stripped.search + stripped.hash
+			);
+		}
+
+		// One-shot auto-link refusal notice. Reason key is a stable
+		// snake_case identifier the OIDC callback emitted; map each to
+		// localized copy and strip the param so a reload doesn't
+		// re-surface the same notice.
+		const loginErrorKey = page.url.searchParams.get('login_error');
+		if (loginErrorKey) {
+			loginErrorNotice = loginErrorMessage(loginErrorKey);
+			const stripped = new URL(page.url);
+			stripped.searchParams.delete('login_error');
 			window.history.replaceState(
 				window.history.state,
 				'',
@@ -386,481 +446,509 @@
 			     magic-link toggle) in place. Guarding the whole form
 			     behind `booting` caused a "logo only, then form" flash
 			     on first paint. -->
-		<h1 class="auth-title">
-			{#if mode === 'login'}
-				{t('auth.sign_in', 'Sign in')}
-			{:else if mode === 'register'}
-				{t('auth.register', 'Create account')}
-			{:else}
-				{t('auth.setup_title', 'Initial setup')}
+		{#if loginErrorNotice}
+			<!-- Dedicated error view — hides the login form entirely
+			     until the user dismisses. Lands the user on a focused
+			     "this went wrong" screen instead of a form buried
+			     under a red banner. Sibling of the callback redirect
+			     that surfaced this notice in the first place.
+			     Reuses `.auth-title` and `.auth-button` for theme
+			     consistency with the normal login/register/setup views. -->
+			<div class="auth-error-view" role="alert" data-testid="login-error-notice">
+				<h1 class="auth-title">{t('auth.login_error_title', 'Sign-in failed')}</h1>
+				<p class="auth-error-view__message">{loginErrorNotice}</p>
+				<button
+					type="button"
+					class="auth-button"
+					data-testid="login-error-back-btn"
+					onclick={() => (loginErrorNotice = null)}
+				>
+					{t('auth.login_error_back_to_login', 'Back to login')}
+				</button>
+			</div>
+		{:else}
+			<h1 class="auth-title">
+				{#if mode === 'login'}
+					{t('auth.sign_in', 'Sign in')}
+				{:else if mode === 'register'}
+					{t('auth.register', 'Create account')}
+				{:else}
+					{t('auth.setup_title', 'Initial setup')}
+				{/if}
+			</h1>
+
+			{#if sessionExpiredNotice}
+				<div
+					class="auth-error auth-error--dismissible"
+					style="display: flex"
+					role="alert"
+					data-testid="login-session-expired-notice"
+				>
+					<span>{t('auth.session_expired', 'Your session expired. Please sign in again.')}</span>
+					<button
+						type="button"
+						class="auth-notice-dismiss"
+						aria-label={t('common.dismiss', 'Dismiss')}
+						data-testid="login-session-expired-dismiss-btn"
+						onclick={() => (sessionExpiredNotice = false)}>×</button
+					>
+				</div>
 			{/if}
-		</h1>
 
-		{#if sessionExpiredNotice}
-			<div
-				class="auth-error auth-error--dismissible"
-				style="display: flex"
-				role="alert"
-				data-testid="login-session-expired-notice"
-			>
-				<span>{t('auth.session_expired', 'Your session expired. Please sign in again.')}</span>
-				<button
-					type="button"
-					class="auth-notice-dismiss"
-					aria-label={t('common.dismiss', 'Dismiss')}
-					data-testid="login-session-expired-dismiss-btn"
-					onclick={() => (sessionExpiredNotice = false)}>×</button
+			{#if postRegisterNotice && mode === 'login'}
+				<div
+					class="auth-success auth-error--dismissible"
+					style="display: flex"
+					role="status"
+					data-testid="login-post-register-notice"
 				>
-			</div>
-		{/if}
+					<span>{postRegisterNotice}</span>
+					<button
+						type="button"
+						class="auth-notice-dismiss"
+						aria-label={t('common.dismiss', 'Dismiss')}
+						data-testid="login-post-register-dismiss-btn"
+						onclick={() => (postRegisterNotice = null)}>×</button
+					>
+				</div>
+			{/if}
 
-		{#if postRegisterNotice && mode === 'login'}
-			<div
-				class="auth-success auth-error--dismissible"
-				style="display: flex"
-				role="status"
-				data-testid="login-post-register-notice"
-			>
-				<span>{postRegisterNotice}</span>
-				<button
-					type="button"
-					class="auth-notice-dismiss"
-					aria-label={t('common.dismiss', 'Dismiss')}
-					data-testid="login-post-register-dismiss-btn"
-					onclick={() => (postRegisterNotice = null)}>×</button
-				>
-			</div>
-		{/if}
-
-		{#if mode === 'login'}
-			<!-- Unified login form. One identifier + one (optional)
+			{#if mode === 'login'}
+				<!-- Unified login form. One identifier + one (optional)
 				     password field drive both flows:
 				       * password filled       → POST /api/auth/login
 				       * password empty        → POST /api/auth/magic-link/send
 				       * password-only server  → password field is required, no hint
 				       * magic-link-only server → password field hides entirely -->
-			{#if passwordLoginEnabled || magicLinkLoginEnabled}
-				{#if error}
-					<div
-						class={emailNotVerified ? 'auth-success' : 'auth-error'}
-						style="display: block"
-						role="alert"
+				{#if passwordLoginEnabled || magicLinkLoginEnabled}
+					{#if error}
+						<div
+							class={emailNotVerified ? 'auth-success' : 'auth-error'}
+							style="display: block"
+							role="alert"
+						>
+							{error}
+						</div>
+					{/if}
+					{#if magicStatus}
+						<div
+							class={magicStatus.ok
+								? 'auth-status auth-status-success'
+								: 'auth-status auth-status-error'}
+							role={magicStatus.ok ? 'status' : 'alert'}
+						>
+							{magicStatus.text}
+						</div>
+					{/if}
+					<form class="auth-form" data-testid="login-form" onsubmit={onLogin} novalidate>
+						<div class="auth-input-group">
+							<label class="auth-label" for="login-username">
+								{t('auth.login_identifier', 'Username or email')}
+							</label>
+							<div class="auth-input-wrap auth-input-wrap--user">
+								<input
+									id="login-username"
+									class="auth-input"
+									data-testid="login-username-input"
+									type="text"
+									bind:value={username}
+									bind:this={loginIdentifierInput}
+									autocomplete="username"
+									placeholder={t(
+										'auth.login_identifier_placeholder',
+										'Enter your username or email'
+									)}
+									required
+									disabled={busy}
+								/>
+							</div>
+						</div>
+
+						{#if passwordLoginEnabled}
+							<div class="auth-input-group">
+								<label class="auth-label" for="login-password">
+									{#if magicLinkLoginEnabled}
+										{t('auth.password_or_link_hint', 'Password (leave blank for a sign-in link)')}
+									{:else}
+										{t('auth.password', 'Password')}
+									{/if}
+								</label>
+								<div class="auth-input-wrap auth-input-wrap--lock has-toggle">
+									<input
+										id="login-password"
+										class="auth-input"
+										data-testid="login-password-input"
+										type={showPassword ? 'text' : 'password'}
+										bind:value={password}
+										onkeydown={onPwKey}
+										onkeyup={onPwKey}
+										autocomplete="current-password"
+										required={!magicLinkLoginEnabled}
+										disabled={busy}
+									/>
+									<button
+										type="button"
+										class="auth-pw-toggle"
+										aria-pressed={showPassword}
+										data-testid="login-password-toggle-btn"
+										aria-label={t('auth.toggle_password', 'Show password')}
+										onclick={() => (showPassword = !showPassword)}
+									></button>
+								</div>
+								{#if capsOn}
+									<div class="auth-caps-warning">{t('auth.caps_lock', 'Caps Lock is on')}</div>
+								{/if}
+							</div>
+						{/if}
+
+						<button
+							class="auth-button"
+							type="submit"
+							data-testid="login-submit-btn"
+							disabled={busy}
+							aria-busy={busy}
+						>
+							{#if busy}
+								{submitAsMagicLink
+									? t('auth.sending', 'Sending…')
+									: t('auth.signing_in', 'Signing in…')}
+							{:else if submitAsMagicLink}
+								{t('auth.magicLinkSubmit', 'Send sign-in link')}
+							{:else}
+								{t('auth.sign_in', 'Sign in')}
+							{/if}
+						</button>
+					</form>
+				{/if}
+
+				{#if oidc.enabled}
+					{#if passwordLoginEnabled}
+						<div class="auth-divider"><span>{t('auth.or', 'or')}</span></div>
+					{/if}
+					<!-- Backend OIDC authorize endpoint (not a SvelteKit route). -->
+					<a
+						class="auth-button auth-button-oidc"
+						data-testid="login-oidc-btn"
+						href={oidc.authorize_endpoint}
+						rel="external"
 					>
-						{error}
+						{t(
+							'auth.sso_login_provider',
+							{ provider: oidc.provider_name ?? 'SSO' },
+							'Sign in with {{provider}}'
+						)}
+					</a>
+				{/if}
+
+				{#if passwordLoginEnabled}
+					<div class="auth-toggle">
+						{t('auth.no_account', 'No account?')}
+						<button
+							class="auth-toggle-link"
+							data-testid="login-to-register-btn"
+							onclick={() => (mode = 'register')}
+						>
+							{t('auth.register', 'Create one')}
+						</button>
 					</div>
 				{/if}
-				{#if magicStatus}
-					<div
-						class={magicStatus.ok
-							? 'auth-status auth-status-success'
-							: 'auth-status auth-status-error'}
-						role={magicStatus.ok ? 'status' : 'alert'}
-					>
-						{magicStatus.text}
+
+				{#if setupAvailable}
+					<div class="auth-toggle">
+						{t('auth.admin_setup', 'First time?')}
+						<button
+							class="auth-toggle-link"
+							data-testid="login-to-setup-btn"
+							onclick={() => (mode = 'setup')}
+						>
+							{t('auth.setup', 'Set up administrator')}
+						</button>
 					</div>
 				{/if}
-				<form class="auth-form" data-testid="login-form" onsubmit={onLogin} novalidate>
+			{:else if mode === 'register'}
+				{#if regError}<div class="auth-error" style="display: block" role="alert">
+						{regError}
+					</div>{/if}
+				<form class="auth-form" data-testid="login-register-form" onsubmit={onRegister} novalidate>
+					<!-- Email is the only required identifier since PR 18 — the
+					     backend accepts email-only signup and mints a welcome
+					     magic-link. Username is optional at this stage; the user
+					     can claim a handle later via profile settings. -->
 					<div class="auth-input-group">
-						<label class="auth-label" for="login-username">
-							{t('auth.login_identifier', 'Username or email')}
+						<label class="auth-label" for="reg-email">{t('auth.email', 'Email')}</label>
+						<input
+							id="reg-email"
+							class="auth-input"
+							data-testid="login-register-email-input"
+							type="email"
+							bind:value={regEmail}
+							bind:this={registerEmailInput}
+							autocomplete="email"
+							required
+							disabled={busy}
+						/>
+					</div>
+					<div class="auth-input-group">
+						<label class="auth-label" for="reg-username">
+							{t('auth.username_optional', 'Username (optional)')}
+						</label>
+						<input
+							id="reg-username"
+							class="auth-input"
+							data-testid="login-register-username-input"
+							bind:value={regUsername}
+							autocomplete="username"
+							disabled={busy}
+						/>
+					</div>
+					<!-- Password fields hide entirely when policy forbids password
+					     login — the whole form becomes email-only in that mode. -->
+					{#if passwordLoginEnabled}
+						<div class="auth-input-group">
+							<label class="auth-label" for="reg-password">
+								{t(
+									'auth.password_optional',
+									'Password (optional — leave blank for a sign-in link)'
+								)}
+							</label>
+							<div class="auth-input-wrap auth-input-wrap--lock has-toggle">
+								<input
+									id="reg-password"
+									class="auth-input"
+									data-testid="login-register-password-input"
+									type={regShowPassword ? 'text' : 'password'}
+									bind:value={regPassword}
+									onkeydown={onRegPwKey}
+									onkeyup={onRegPwKey}
+									autocomplete="new-password"
+									disabled={busy}
+								/>
+								<button
+									type="button"
+									class="auth-pw-toggle"
+									aria-pressed={regShowPassword}
+									data-testid="login-register-password-toggle-btn"
+									aria-label={t('auth.toggle_password', 'Show password')}
+									onclick={() => (regShowPassword = !regShowPassword)}
+								></button>
+							</div>
+							{#if regCapsOn}
+								<div class="auth-caps-warning">{t('auth.caps_lock', 'Caps Lock is on')}</div>
+							{/if}
+						</div>
+						{#if !regEmailOnly}
+							<div class="auth-input-group">
+								<label class="auth-label" for="reg-confirm"
+									>{t('auth.confirm_password', 'Confirm password')}</label
+								>
+								<div class="auth-input-wrap auth-input-wrap--lock has-toggle">
+									<input
+										id="reg-confirm"
+										class="auth-input"
+										data-testid="login-register-confirm-input"
+										type={regShowConfirm ? 'text' : 'password'}
+										bind:value={regConfirm}
+										onkeydown={onRegPwKey}
+										onkeyup={onRegPwKey}
+										autocomplete="new-password"
+										required
+										disabled={busy}
+									/>
+									<button
+										type="button"
+										class="auth-pw-toggle"
+										aria-pressed={regShowConfirm}
+										data-testid="login-register-confirm-toggle-btn"
+										aria-label={t('auth.toggle_password', 'Show password')}
+										onclick={() => (regShowConfirm = !regShowConfirm)}
+									></button>
+								</div>
+								{#if matchState}
+									<div
+										class="auth-match show {matchState === 'ok'
+											? 'auth-match--ok'
+											: 'auth-match--bad'}"
+									>
+										{matchState === 'ok'
+											? t('auth.passwords_match', 'Passwords match')
+											: t('auth.passwords_mismatch', "Passwords don't match")}
+									</div>
+								{/if}
+							</div>
+						{/if}
+					{/if}
+					<button
+						class="auth-button"
+						type="submit"
+						data-testid="login-register-submit-btn"
+						disabled={busy}
+						aria-busy={busy}
+					>
+						{!passwordLoginEnabled || regEmailOnly
+							? t('auth.register_email_only', 'Send me a sign-in link')
+							: t('auth.register', 'Create account')}
+					</button>
+				</form>
+				<div class="auth-toggle">
+					{t('auth.have_account', 'Already have an account?')}
+					<button
+						class="auth-toggle-link"
+						data-testid="login-register-to-login-btn"
+						onclick={() => (mode = 'login')}
+					>
+						{t('auth.sign_in', 'Sign in')}
+					</button>
+				</div>
+			{:else}
+				<div class="setup-steps">
+					<div class="setup-step">
+						<div class="step-number active">1</div>
+						<div class="step-title active">{t('auth.setup_step1', 'Admin')}</div>
+					</div>
+					<div class="setup-step">
+						<div class="step-number">2</div>
+						<div class="step-title">{t('auth.setup_step2', 'System')}</div>
+					</div>
+					<div class="setup-step">
+						<div class="step-number">3</div>
+						<div class="step-title">{t('auth.setup_step3', 'Completed')}</div>
+					</div>
+				</div>
+
+				{#if setupError}<div class="auth-error" style="display: block" role="alert">
+						{setupError}
+					</div>{/if}
+				{#if setupSuccess}<div class="auth-success" style="display: block">{setupSuccess}</div>{/if}
+
+				<form class="auth-form" data-testid="login-setup-form" onsubmit={onSetup} novalidate>
+					<div class="auth-input-group">
+						<label class="auth-label" for="setup-username">
+							{t('auth.admin_username', 'Administrator username')}
 						</label>
 						<div class="auth-input-wrap auth-input-wrap--user">
 							<input
-								id="login-username"
+								id="setup-username"
 								class="auth-input"
-								data-testid="login-username-input"
+								data-testid="login-setup-username-input"
 								type="text"
-								bind:value={username}
-								bind:this={loginIdentifierInput}
-								autocomplete="username"
-								placeholder={t('auth.login_identifier_placeholder', 'Enter your username or email')}
+								value="admin"
+								readonly
+							/>
+						</div>
+					</div>
+
+					<div class="auth-input-group">
+						<label class="auth-label" for="setup-email">
+							{t('auth.admin_email', 'Administrator email')}
+						</label>
+						<div class="auth-input-wrap auth-input-wrap--mail">
+							<input
+								id="setup-email"
+								class="auth-input"
+								data-testid="login-setup-email-input"
+								type="email"
+								bind:value={setupEmail}
+								bind:this={setupEmailInput}
+								autocomplete="email"
 								required
 								disabled={busy}
 							/>
 						</div>
 					</div>
 
-					{#if passwordLoginEnabled}
-						<div class="auth-input-group">
-							<label class="auth-label" for="login-password">
-								{#if magicLinkLoginEnabled}
-									{t('auth.password_or_link_hint', 'Password (leave blank for a sign-in link)')}
-								{:else}
-									{t('auth.password', 'Password')}
-								{/if}
-							</label>
-							<div class="auth-input-wrap auth-input-wrap--lock has-toggle">
-								<input
-									id="login-password"
-									class="auth-input"
-									data-testid="login-password-input"
-									type={showPassword ? 'text' : 'password'}
-									bind:value={password}
-									onkeydown={onPwKey}
-									onkeyup={onPwKey}
-									autocomplete="current-password"
-									required={!magicLinkLoginEnabled}
-									disabled={busy}
-								/>
-								<button
-									type="button"
-									class="auth-pw-toggle"
-									aria-pressed={showPassword}
-									data-testid="login-password-toggle-btn"
-									aria-label={t('auth.toggle_password', 'Show password')}
-									onclick={() => (showPassword = !showPassword)}
-								></button>
-							</div>
-							{#if capsOn}
-								<div class="auth-caps-warning">{t('auth.caps_lock', 'Caps Lock is on')}</div>
-							{/if}
-						</div>
-					{/if}
-
-					<button
-						class="auth-button"
-						type="submit"
-						data-testid="login-submit-btn"
-						disabled={busy}
-						aria-busy={busy}
-					>
-						{#if busy}
-							{submitAsMagicLink
-								? t('auth.sending', 'Sending…')
-								: t('auth.signing_in', 'Signing in…')}
-						{:else if submitAsMagicLink}
-							{t('auth.magicLinkSubmit', 'Send sign-in link')}
-						{:else}
-							{t('auth.sign_in', 'Sign in')}
-						{/if}
-					</button>
-				</form>
-			{/if}
-
-			{#if oidc.enabled}
-				{#if passwordLoginEnabled}
-					<div class="auth-divider"><span>{t('auth.or', 'or')}</span></div>
-				{/if}
-				<!-- Backend OIDC authorize endpoint (not a SvelteKit route). -->
-				<a
-					class="auth-button auth-button-oidc"
-					data-testid="login-oidc-btn"
-					href={oidc.authorize_endpoint}
-					rel="external"
-				>
-					{t(
-						'auth.sso_login_provider',
-						{ provider: oidc.provider_name ?? 'SSO' },
-						'Sign in with {{provider}}'
-					)}
-				</a>
-			{/if}
-
-			{#if passwordLoginEnabled}
-				<div class="auth-toggle">
-					{t('auth.no_account', 'No account?')}
-					<button
-						class="auth-toggle-link"
-						data-testid="login-to-register-btn"
-						onclick={() => (mode = 'register')}
-					>
-						{t('auth.register', 'Create one')}
-					</button>
-				</div>
-			{/if}
-
-			{#if setupAvailable}
-				<div class="auth-toggle">
-					{t('auth.admin_setup', 'First time?')}
-					<button
-						class="auth-toggle-link"
-						data-testid="login-to-setup-btn"
-						onclick={() => (mode = 'setup')}
-					>
-						{t('auth.setup', 'Set up administrator')}
-					</button>
-				</div>
-			{/if}
-		{:else if mode === 'register'}
-			{#if regError}<div class="auth-error" style="display: block" role="alert">
-					{regError}
-				</div>{/if}
-			<form class="auth-form" data-testid="login-register-form" onsubmit={onRegister} novalidate>
-				<!-- Email is the only required identifier since PR 18 — the
-					     backend accepts email-only signup and mints a welcome
-					     magic-link. Username is optional at this stage; the user
-					     can claim a handle later via profile settings. -->
-				<div class="auth-input-group">
-					<label class="auth-label" for="reg-email">{t('auth.email', 'Email')}</label>
-					<input
-						id="reg-email"
-						class="auth-input"
-						data-testid="login-register-email-input"
-						type="email"
-						bind:value={regEmail}
-						bind:this={registerEmailInput}
-						autocomplete="email"
-						required
-						disabled={busy}
-					/>
-				</div>
-				<div class="auth-input-group">
-					<label class="auth-label" for="reg-username">
-						{t('auth.username_optional', 'Username (optional)')}
-					</label>
-					<input
-						id="reg-username"
-						class="auth-input"
-						data-testid="login-register-username-input"
-						bind:value={regUsername}
-						autocomplete="username"
-						disabled={busy}
-					/>
-				</div>
-				<!-- Password fields hide entirely when policy forbids password
-					     login — the whole form becomes email-only in that mode. -->
-				{#if passwordLoginEnabled}
 					<div class="auth-input-group">
-						<label class="auth-label" for="reg-password">
-							{t('auth.password_optional', 'Password (optional — leave blank for a sign-in link)')}
+						<label class="auth-label" for="setup-password">
+							{t('auth.admin_password', 'Administrator password')}
 						</label>
 						<div class="auth-input-wrap auth-input-wrap--lock has-toggle">
 							<input
-								id="reg-password"
+								id="setup-password"
 								class="auth-input"
-								data-testid="login-register-password-input"
-								type={regShowPassword ? 'text' : 'password'}
-								bind:value={regPassword}
-								onkeydown={onRegPwKey}
-								onkeyup={onRegPwKey}
+								data-testid="login-setup-password-input"
+								type={setupShowPassword ? 'text' : 'password'}
+								bind:value={setupPassword}
+								onkeydown={onSetupPwKey}
+								onkeyup={onSetupPwKey}
 								autocomplete="new-password"
+								minlength="8"
+								required
 								disabled={busy}
 							/>
 							<button
 								type="button"
 								class="auth-pw-toggle"
-								aria-pressed={regShowPassword}
-								data-testid="login-register-password-toggle-btn"
+								aria-pressed={setupShowPassword}
+								data-testid="login-setup-password-toggle-btn"
 								aria-label={t('auth.toggle_password', 'Show password')}
-								onclick={() => (regShowPassword = !regShowPassword)}
+								onclick={() => (setupShowPassword = !setupShowPassword)}
 							></button>
 						</div>
-						{#if regCapsOn}
+						{#if setupCapsOn}
 							<div class="auth-caps-warning">{t('auth.caps_lock', 'Caps Lock is on')}</div>
 						{/if}
 					</div>
-					{#if !regEmailOnly}
-						<div class="auth-input-group">
-							<label class="auth-label" for="reg-confirm"
-								>{t('auth.confirm_password', 'Confirm password')}</label
+
+					<div class="auth-input-group">
+						<label class="auth-label" for="setup-confirm">
+							{t('auth.confirm_password', 'Confirm password')}
+						</label>
+						<div class="auth-input-wrap auth-input-wrap--lock has-toggle">
+							<input
+								id="setup-confirm"
+								class="auth-input"
+								data-testid="login-setup-confirm-input"
+								type={setupShowConfirm ? 'text' : 'password'}
+								bind:value={setupConfirm}
+								onkeydown={onSetupPwKey}
+								onkeyup={onSetupPwKey}
+								autocomplete="new-password"
+								required
+								disabled={busy}
+							/>
+							<button
+								type="button"
+								class="auth-pw-toggle"
+								aria-pressed={setupShowConfirm}
+								data-testid="login-setup-confirm-toggle-btn"
+								aria-label={t('auth.toggle_password', 'Show password')}
+								onclick={() => (setupShowConfirm = !setupShowConfirm)}
+							></button>
+						</div>
+						{#if setupMatchState}
+							<div
+								class="auth-match show {setupMatchState === 'ok'
+									? 'auth-match--ok'
+									: 'auth-match--bad'}"
 							>
-							<div class="auth-input-wrap auth-input-wrap--lock has-toggle">
-								<input
-									id="reg-confirm"
-									class="auth-input"
-									data-testid="login-register-confirm-input"
-									type={regShowConfirm ? 'text' : 'password'}
-									bind:value={regConfirm}
-									onkeydown={onRegPwKey}
-									onkeyup={onRegPwKey}
-									autocomplete="new-password"
-									required
-									disabled={busy}
-								/>
-								<button
-									type="button"
-									class="auth-pw-toggle"
-									aria-pressed={regShowConfirm}
-									data-testid="login-register-confirm-toggle-btn"
-									aria-label={t('auth.toggle_password', 'Show password')}
-									onclick={() => (regShowConfirm = !regShowConfirm)}
-								></button>
+								{setupMatchState === 'ok'
+									? t('auth.passwords_match', 'Passwords match')
+									: t('auth.passwords_mismatch', "Passwords don't match")}
 							</div>
-							{#if matchState}
-								<div
-									class="auth-match show {matchState === 'ok'
-										? 'auth-match--ok'
-										: 'auth-match--bad'}"
-								>
-									{matchState === 'ok'
-										? t('auth.passwords_match', 'Passwords match')
-										: t('auth.passwords_mismatch', "Passwords don't match")}
-								</div>
-							{/if}
-						</div>
-					{/if}
-				{/if}
-				<button
-					class="auth-button"
-					type="submit"
-					data-testid="login-register-submit-btn"
-					disabled={busy}
-					aria-busy={busy}
-				>
-					{!passwordLoginEnabled || regEmailOnly
-						? t('auth.register_email_only', 'Send me a sign-in link')
-						: t('auth.register', 'Create account')}
-				</button>
-			</form>
-			<div class="auth-toggle">
-				{t('auth.have_account', 'Already have an account?')}
-				<button
-					class="auth-toggle-link"
-					data-testid="login-register-to-login-btn"
-					onclick={() => (mode = 'login')}
-				>
-					{t('auth.sign_in', 'Sign in')}
-				</button>
-			</div>
-		{:else}
-			<div class="setup-steps">
-				<div class="setup-step">
-					<div class="step-number active">1</div>
-					<div class="step-title active">{t('auth.setup_step1', 'Admin')}</div>
-				</div>
-				<div class="setup-step">
-					<div class="step-number">2</div>
-					<div class="step-title">{t('auth.setup_step2', 'System')}</div>
-				</div>
-				<div class="setup-step">
-					<div class="step-number">3</div>
-					<div class="step-title">{t('auth.setup_step3', 'Completed')}</div>
-				</div>
-			</div>
-
-			{#if setupError}<div class="auth-error" style="display: block" role="alert">
-					{setupError}
-				</div>{/if}
-			{#if setupSuccess}<div class="auth-success" style="display: block">{setupSuccess}</div>{/if}
-
-			<form class="auth-form" data-testid="login-setup-form" onsubmit={onSetup} novalidate>
-				<div class="auth-input-group">
-					<label class="auth-label" for="setup-username">
-						{t('auth.admin_username', 'Administrator username')}
-					</label>
-					<div class="auth-input-wrap auth-input-wrap--user">
-						<input
-							id="setup-username"
-							class="auth-input"
-							data-testid="login-setup-username-input"
-							type="text"
-							value="admin"
-							readonly
-						/>
+						{/if}
 					</div>
+
+					<button
+						class="auth-button"
+						type="submit"
+						data-testid="login-setup-submit-btn"
+						disabled={busy}
+						aria-busy={busy}
+					>
+						{t('auth.create_admin', 'Create administrator')}
+					</button>
+				</form>
+
+				<div class="auth-toggle">
+					{t('auth.back_to_login', 'Already configured?')}
+					<button
+						class="auth-toggle-link"
+						data-testid="login-setup-to-login-btn"
+						onclick={() => (mode = 'login')}
+					>
+						{t('auth.sign_in', 'Sign in')}
+					</button>
 				</div>
-
-				<div class="auth-input-group">
-					<label class="auth-label" for="setup-email">
-						{t('auth.admin_email', 'Administrator email')}
-					</label>
-					<div class="auth-input-wrap auth-input-wrap--mail">
-						<input
-							id="setup-email"
-							class="auth-input"
-							data-testid="login-setup-email-input"
-							type="email"
-							bind:value={setupEmail}
-							bind:this={setupEmailInput}
-							autocomplete="email"
-							required
-							disabled={busy}
-						/>
-					</div>
-				</div>
-
-				<div class="auth-input-group">
-					<label class="auth-label" for="setup-password">
-						{t('auth.admin_password', 'Administrator password')}
-					</label>
-					<div class="auth-input-wrap auth-input-wrap--lock has-toggle">
-						<input
-							id="setup-password"
-							class="auth-input"
-							data-testid="login-setup-password-input"
-							type={setupShowPassword ? 'text' : 'password'}
-							bind:value={setupPassword}
-							onkeydown={onSetupPwKey}
-							onkeyup={onSetupPwKey}
-							autocomplete="new-password"
-							minlength="8"
-							required
-							disabled={busy}
-						/>
-						<button
-							type="button"
-							class="auth-pw-toggle"
-							aria-pressed={setupShowPassword}
-							data-testid="login-setup-password-toggle-btn"
-							aria-label={t('auth.toggle_password', 'Show password')}
-							onclick={() => (setupShowPassword = !setupShowPassword)}
-						></button>
-					</div>
-					{#if setupCapsOn}
-						<div class="auth-caps-warning">{t('auth.caps_lock', 'Caps Lock is on')}</div>
-					{/if}
-				</div>
-
-				<div class="auth-input-group">
-					<label class="auth-label" for="setup-confirm">
-						{t('auth.confirm_password', 'Confirm password')}
-					</label>
-					<div class="auth-input-wrap auth-input-wrap--lock has-toggle">
-						<input
-							id="setup-confirm"
-							class="auth-input"
-							data-testid="login-setup-confirm-input"
-							type={setupShowConfirm ? 'text' : 'password'}
-							bind:value={setupConfirm}
-							onkeydown={onSetupPwKey}
-							onkeyup={onSetupPwKey}
-							autocomplete="new-password"
-							required
-							disabled={busy}
-						/>
-						<button
-							type="button"
-							class="auth-pw-toggle"
-							aria-pressed={setupShowConfirm}
-							data-testid="login-setup-confirm-toggle-btn"
-							aria-label={t('auth.toggle_password', 'Show password')}
-							onclick={() => (setupShowConfirm = !setupShowConfirm)}
-						></button>
-					</div>
-					{#if setupMatchState}
-						<div
-							class="auth-match show {setupMatchState === 'ok'
-								? 'auth-match--ok'
-								: 'auth-match--bad'}"
-						>
-							{setupMatchState === 'ok'
-								? t('auth.passwords_match', 'Passwords match')
-								: t('auth.passwords_mismatch', "Passwords don't match")}
-						</div>
-					{/if}
-				</div>
-
-				<button
-					class="auth-button"
-					type="submit"
-					data-testid="login-setup-submit-btn"
-					disabled={busy}
-					aria-busy={busy}
-				>
-					{t('auth.create_admin', 'Create administrator')}
-				</button>
-			</form>
-
-			<div class="auth-toggle">
-				{t('auth.back_to_login', 'Already configured?')}
-				<button
-					class="auth-toggle-link"
-					data-testid="login-setup-to-login-btn"
-					onclick={() => (mode = 'login')}
-				>
-					{t('auth.sign_in', 'Sign in')}
-				</button>
-			</div>
+			{/if}
 		{/if}
 
 		<div class="auth-lang">
@@ -910,5 +998,23 @@
 
 	.auth-notice-dismiss:hover {
 		opacity: 0.7;
+	}
+
+	/* Dedicated error view — centered in the auth-panel with the
+	   message padded off the title/button. `.auth-button` (from
+	   ported/auth.css) already carries the full-width primary
+	   styling used by the login submit, so the back button lands
+	   right on the existing theme. */
+	.auth-error-view {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--space-4);
+		text-align: center;
+	}
+
+	.auth-error-view__message {
+		color: var(--color-text-secondary);
+		margin: 0;
 	}
 </style>

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -319,6 +319,11 @@
 					'auth.login_error_already_linked_elsewhere',
 					'A local account with this email already exists and is linked to a different SSO identity. Contact your administrator.'
 				);
+			case 'email_ambiguous':
+				return t(
+					'auth.login_error_email_ambiguous',
+					'Multiple local accounts match this email address. Contact your administrator to resolve.'
+				);
 			case 'callback_denied':
 				return t(
 					'auth.login_error_callback_denied',

--- a/frontend/src/routes/profile/+page.svelte
+++ b/frontend/src/routes/profile/+page.svelte
@@ -18,7 +18,7 @@
 		type AppPassword,
 		type ProfilePatch
 	} from '$lib/api/endpoints/profile';
-	import { fetchMe, getOidcProviders } from '$lib/api/endpoints/auth';
+	import { fetchMe, getOidcProviders, startOidcLink, unlinkOidc } from '$lib/api/endpoints/auth';
 	import { SUPPORTED_LOCALES, setLocale, t, type Locale } from '$lib/i18n/index.svelte';
 	import Icon from '$lib/icons/Icon.svelte';
 	import { confirmDialog } from '$lib/stores/dialogs.svelte';
@@ -50,6 +50,12 @@
 
 	let avatarBusy = $state(false);
 	let passwordLoginEnabled = $state(true);
+	// OIDC providers snapshot for the SSO link/unlink card. Populated
+	// on mount; determines whether we render the "Connect SSO" card
+	// (requires oidcEnabled) and what display label to show.
+	let oidcEnabled = $state(false);
+	let oidcProviderName = $state<string>('SSO');
+	let ssoBusy = $state(false);
 
 	// Avatar edit panel.
 	let avatarEditOpen = $state(false);
@@ -82,6 +88,22 @@
 	// their local credential; the new gate lets them, and the backend
 	// refusal covers the pure-SSO case where has_password is false.
 	const showPasswordCard = $derived((session.user?.has_password ?? false) && passwordLoginEnabled);
+
+	// SSO card gates — see docs/plan/oidc-account-linking.md.
+	// Connect: only when OIDC is enabled AND the user isn't already linked.
+	// Disconnect: only when currently OIDC-linked AND the user has an
+	// alternative auth method (password or OPAQUE-registered) — else
+	// unlinking would lock them out.
+	const canConnectSso = $derived(oidcEnabled && !session.user?.federation_kind);
+	// Show the disconnect button whenever the user is OIDC-linked.
+	// The backend guard (`AuthApplicationService::unlink_oidc`) is the
+	// source of truth for the "no alternative auth" refusal — it also
+	// checks `opaque_registered`, which isn't exposed on UserDto today
+	// (deliberately kept off `/api/auth/me` to avoid leaking OPAQUE
+	// adoption status through user-directory endpoints). The UI shows
+	// the button unconditionally and surfaces the backend's 403 as a
+	// user-facing "set a password first" prompt.
+	const canDisconnectSso = $derived(session.user?.federation_kind === 'oidc');
 
 	/**
 	 * Mandatory change-password mode. TRUE when the backend has
@@ -396,10 +418,138 @@
 			// Only an explicit `false` hides the password card; an absent flag
 			// (no OIDC configured) leaves local password login available.
 			if (providers.password_login_enabled === false) passwordLoginEnabled = false;
+			// Capture OIDC state for the SSO link/unlink card. `provider_name`
+			// is the display label the FE renders in the "Connected to X"
+			// affordance.
+			oidcEnabled = providers.enabled === true;
+			if (typeof providers.provider_name === 'string' && providers.provider_name.length > 0) {
+				oidcProviderName = providers.provider_name;
+			}
 		} catch {
 			/* leave password login enabled */
 		}
+
+		// Toast handling for the OIDC-link callback redirect. The
+		// backend redirects here with `?linked=1` on success or
+		// `?link_error=<reason>` on refusal (see plan doc for the
+		// stable reason keys). Show a translated toast and strip the
+		// query params via history.replaceState so a page reload
+		// doesn't re-fire the toast.
+		const params = page.url.searchParams;
+		const linked = params.get('linked');
+		const linkError = params.get('link_error');
+		if (linked === '1') {
+			ui.notify(t('profile.sso_linked_success', 'Single sign-on connected successfully.'), 'info');
+			// Session's federation_kind may still be stale from before
+			// the round-trip; re-fetch to pick up the fresh columns
+			// (federation_kind should now be 'oidc').
+			try {
+				const me = await fetchMe();
+				if (me) session.user = me;
+			} catch {
+				/* stale session is recoverable — next request refreshes */
+			}
+		} else if (linkError) {
+			// Map the stable reason keys to translated messages. Falls
+			// back to a generic message for keys we don't recognise
+			// (forward-compatible with new refusal reasons).
+			const msg = ssoLinkErrorMessage(linkError);
+			ui.notify(msg, 'error');
+		}
+		if (linked !== null || linkError !== null) {
+			const stripped = new URL(page.url);
+			stripped.searchParams.delete('linked');
+			stripped.searchParams.delete('link_error');
+			window.history.replaceState(
+				window.history.state,
+				'',
+				stripped.pathname + stripped.search + stripped.hash
+			);
+		}
 	});
+
+	function ssoLinkErrorMessage(key: string): string {
+		// Keys match the `reason` field of `federation.link_refused`
+		// audit events — see docs/plan/oidc-account-linking.md.
+		switch (key) {
+			case 'email_mismatch':
+				return t(
+					'profile.sso_link_error_email_mismatch',
+					"The email from your SSO provider doesn't match your OxiCloud account email."
+				);
+			case 'email_not_provided':
+				return t(
+					'profile.sso_link_error_email_not_provided',
+					"Your SSO provider didn't return an email address, so we can't verify the link."
+				);
+			case 'already_linked_elsewhere':
+				return t(
+					'profile.sso_link_error_already_linked_elsewhere',
+					'This SSO identity is already linked to a different OxiCloud account.'
+				);
+			case 'already_linked':
+				return t(
+					'profile.sso_link_error_already_linked',
+					'Your account is already linked to a different SSO identity. Disconnect first.'
+				);
+			case 'session_expired':
+				return t(
+					'profile.sso_link_error_session_expired',
+					'Your session expired during the SSO round-trip. Please sign in again.'
+				);
+			default:
+				return t('profile.sso_link_error_generic', 'SSO link failed. Please try again.');
+		}
+	}
+
+	async function onConnectSso() {
+		ssoBusy = true;
+		try {
+			const url = await startOidcLink();
+			// Full-page navigation so the browser leaves the SPA and
+			// hits the IdP; the callback lands back on /profile via
+			// the extended callback dispatch. `goto()` would stay in
+			// the SPA and never leave.
+			window.location.assign(url);
+		} catch (err) {
+			ssoBusy = false;
+			errorToast(err);
+		}
+	}
+
+	async function onDisconnectSso() {
+		const ok = await confirmDialog({
+			title: t('profile.sso_disconnect_confirm_title', 'Disconnect Single Sign-On?'),
+			message: t(
+				'profile.sso_disconnect_confirm_message',
+				"You'll only be able to sign in with your password or OPAQUE credential after this."
+			),
+			confirmText: t('profile.sso_disconnect_confirm_button', 'Disconnect'),
+			danger: true
+		});
+		if (!ok) return;
+		ssoBusy = true;
+		try {
+			await unlinkOidc();
+			const me = await fetchMe();
+			if (me) session.user = me;
+			ui.notify(t('profile.sso_unlinked_success', 'Single sign-on disconnected.'), 'info');
+		} catch (err) {
+			if (err instanceof ApiError && err.errorType === 'AccessDenied') {
+				ui.notify(
+					t(
+						'profile.sso_unlink_no_alt_auth',
+						'Set a password first — otherwise you would be locked out.'
+					),
+					'error'
+				);
+			} else {
+				errorToast(err);
+			}
+		} finally {
+			ssoBusy = false;
+		}
+	}
 </script>
 
 <svelte:head><title>{t('nav.profile', 'Profile')} · OxiCloud</title></svelte:head>
@@ -906,6 +1056,61 @@
 					{t('profile.update_password', 'Update Password')}
 				</button>
 			</form>
+		{/if}
+
+		<!--
+			OIDC identity link / unlink card. See
+			docs/plan/oidc-account-linking.md § UX flow.
+
+			Two mutually-exclusive states: Connect (no federation yet) or
+			Disconnect (currently OIDC-linked). The Connect button
+			navigates to the IdP; the Disconnect button unlinks and
+			refreshes the session. Backend enforces safety checks —
+			email-match on link, no-alternative-auth refusal on unlink.
+		-->
+		{#if canConnectSso}
+			<section class="card sso-card" data-testid="profile-sso-connect-card">
+				<h2><Icon name="key" /> {t('profile.sso_connect_title', 'Connect Single Sign-On')}</h2>
+				<p>
+					{t(
+						'profile.sso_connect_description',
+						{ provider: oidcProviderName },
+						'Link your account to {{provider}} so you can sign in with SSO instead of your password.'
+					)}
+				</p>
+				<button
+					type="button"
+					data-testid="profile-sso-connect-btn"
+					onclick={onConnectSso}
+					disabled={ssoBusy}
+				>
+					{t(
+						'profile.sso_connect_button',
+						{ provider: oidcProviderName },
+						'Connect with {{provider}}'
+					)}
+				</button>
+			</section>
+		{:else if canDisconnectSso}
+			<section class="card sso-card" data-testid="profile-sso-disconnect-card">
+				<h2><Icon name="key" /> {t('profile.sso_disconnect_title', 'Single Sign-On')}</h2>
+				<p>
+					{t(
+						'profile.sso_disconnect_description',
+						{ provider: oidcProviderName },
+						'Your account is connected to {{provider}}. Disconnecting will require you to sign in with your password from now on.'
+					)}
+				</p>
+				<button
+					type="button"
+					class="btn-danger"
+					data-testid="profile-sso-disconnect-btn"
+					onclick={onDisconnectSso}
+					disabled={ssoBusy}
+				>
+					{t('profile.sso_disconnect_button', 'Disconnect Single Sign-On')}
+				</button>
+			</section>
 		{/if}
 	{:else}
 		<p>{t('common.loading', 'Loading…')}</p>

--- a/frontend/src/routes/profile/+page.svelte
+++ b/frontend/src/routes/profile/+page.svelte
@@ -66,8 +66,8 @@
 	let creatingPw = $state(false);
 	let autoExpanded = $state(false);
 
-	const isOidc = $derived(!!session.user?.auth_provider && session.user.auth_provider !== 'local');
-	const isLocal = $derived(!isOidc);
+	const isOidc = $derived(session.user?.federation_kind === 'oidc');
+	const isLocal = $derived(!session.user?.federation_kind);
 	const usernameClaimed = $derived(!!session.user?.username);
 	const isAdmin = $derived(session.user?.role === 'admin');
 	const canEditImage = $derived(session.user?.can_edit_image === true && isLocal);

--- a/frontend/src/routes/profile/+page.svelte
+++ b/frontend/src/routes/profile/+page.svelte
@@ -502,7 +502,8 @@
 		}
 	}
 
-	async function onConnectSso() {
+	async function onConnectSso(e: SubmitEvent) {
+		e.preventDefault();
 		ssoBusy = true;
 		try {
 			const url = await startOidcLink();
@@ -517,7 +518,8 @@
 		}
 	}
 
-	async function onDisconnectSso() {
+	async function onDisconnectSso(e: SubmitEvent) {
+		e.preventDefault();
 		const ok = await confirmDialog({
 			title: t('profile.sso_disconnect_confirm_title', 'Disconnect Single Sign-On?'),
 			message: t(
@@ -1069,8 +1071,8 @@
 			email-match on link, no-alternative-auth refusal on unlink.
 		-->
 		{#if canConnectSso}
-			<section class="card sso-card" data-testid="profile-sso-connect-card">
-				<h2><Icon name="key" /> {t('profile.sso_connect_title', 'Connect Single Sign-On')}</h2>
+			<form class="card sso-card" data-testid="profile-sso-connect-card" onsubmit={onConnectSso}>
+				<h2><Icon name="link" /> {t('profile.sso_connect_title', 'Connect Single Sign-On')}</h2>
 				<p>
 					{t(
 						'profile.sso_connect_description',
@@ -1078,22 +1080,21 @@
 						'Link your account to {{provider}} so you can sign in with SSO instead of your password.'
 					)}
 				</p>
-				<button
-					type="button"
-					data-testid="profile-sso-connect-btn"
-					onclick={onConnectSso}
-					disabled={ssoBusy}
-				>
+				<button type="submit" data-testid="profile-sso-connect-btn" disabled={ssoBusy}>
 					{t(
 						'profile.sso_connect_button',
 						{ provider: oidcProviderName },
 						'Connect with {{provider}}'
 					)}
 				</button>
-			</section>
+			</form>
 		{:else if canDisconnectSso}
-			<section class="card sso-card" data-testid="profile-sso-disconnect-card">
-				<h2><Icon name="key" /> {t('profile.sso_disconnect_title', 'Single Sign-On')}</h2>
+			<form
+				class="card sso-card"
+				data-testid="profile-sso-disconnect-card"
+				onsubmit={onDisconnectSso}
+			>
+				<h2><Icon name="link" /> {t('profile.sso_disconnect_title', 'Single Sign-On')}</h2>
 				<p>
 					{t(
 						'profile.sso_disconnect_description',
@@ -1101,16 +1102,10 @@
 						'Your account is connected to {{provider}}. Disconnecting will require you to sign in with your password from now on.'
 					)}
 				</p>
-				<button
-					type="button"
-					class="btn-danger"
-					data-testid="profile-sso-disconnect-btn"
-					onclick={onDisconnectSso}
-					disabled={ssoBusy}
-				>
+				<button type="submit" data-testid="profile-sso-disconnect-btn" disabled={ssoBusy}>
 					{t('profile.sso_disconnect_button', 'Disconnect Single Sign-On')}
 				</button>
-			</section>
+			</form>
 		{/if}
 	{:else}
 		<p>{t('common.loading', 'Loading…')}</p>

--- a/frontend/src/routes/profile/+page.svelte
+++ b/frontend/src/routes/profile/+page.svelte
@@ -453,8 +453,10 @@
 			// Map the stable reason keys to translated messages. Falls
 			// back to a generic message for keys we don't recognise
 			// (forward-compatible with new refusal reasons).
+			// 10 s dwell (vs the 4 s default) — the copy is long enough
+			// that the default vanishes before the user finishes reading.
 			const msg = ssoLinkErrorMessage(linkError);
-			ui.notify(msg, 'error');
+			ui.notify(msg, 'error', 10000);
 		}
 		if (linked !== null || linkError !== null) {
 			const stripped = new URL(page.url);
@@ -537,13 +539,14 @@
 			if (me) session.user = me;
 			ui.notify(t('profile.sso_unlinked_success', 'Single sign-on disconnected.'), 'info');
 		} catch (err) {
-			if (err instanceof ApiError && err.errorType === 'AccessDenied') {
+			if (err instanceof ApiError && err.errorType === 'NoAlternativeAuth') {
 				ui.notify(
 					t(
 						'profile.sso_unlink_no_alt_auth',
 						'Set a password first — otherwise you would be locked out.'
 					),
-					'error'
+					'error',
+					10000
 				);
 			} else {
 				errorToast(err);

--- a/frontend/static/locales/en.json
+++ b/frontend/static/locales/en.json
@@ -727,7 +727,15 @@
     "sign_in": "Sign in",
     "signing_in": "Signing in…",
     "sending": "Sending…",
-    "toggle_password": "Show password"
+    "toggle_password": "Show password",
+    "login_error_title": "Sign-in failed",
+    "login_error_back_to_login": "Back to login",
+    "login_error_auto_link_disabled": "This server does not auto-link SSO accounts. Sign in with your existing credentials, then connect SSO from your profile.",
+    "login_error_auto_link_email_not_verified": "Your SSO provider did not confirm your email address. Verify your email at your identity provider, then try again.",
+    "login_error_already_linked_elsewhere": "A local account with this email already exists and is linked to a different SSO identity. Contact your administrator.",
+    "login_error_callback_denied": "Your sign-in link expired or was already used. Please try signing in again.",
+    "login_error_callback_failed": "SSO sign-in couldn't complete. Please try again.",
+    "login_error_generic": "SSO sign-in was refused. Please try again."
   },
   "storage": {
     "title": "Storage",
@@ -1370,7 +1378,18 @@
     "language": "Language",
     "language_auto": "Automatic",
     "password_mismatch": "Passwords do not match",
-    "saved": "Profile saved"
+    "saved": "Profile saved",
+    "sso_connect_title": "Connect Single Sign-On",
+    "sso_connect_description": "Link your account to {{provider}} so you can sign in with SSO instead of your password.",
+    "sso_connect_button": "Connect with {{provider}}",
+    "sso_disconnect_title": "Single Sign-On",
+    "sso_disconnect_description": "Your account is connected to {{provider}}. Disconnecting will require you to sign in with your password from now on.",
+    "sso_disconnect_button": "Disconnect Single Sign-On",
+    "sso_disconnect_confirm_title": "Disconnect Single Sign-On?",
+    "sso_disconnect_confirm_message": "You'll only be able to sign in with your password or OPAQUE credential after this.",
+    "sso_disconnect_confirm_button": "Disconnect",
+    "sso_unlinked_success": "Single sign-on disconnected.",
+    "sso_unlink_no_alt_auth": "Set a password first — otherwise you would be locked out."
   },
   "upload": {
     "uploading": "Uploading...",

--- a/frontend/static/locales/fr.json
+++ b/frontend/static/locales/fr.json
@@ -564,7 +564,15 @@
     "magic_hint": "Pas de mot de passe ? Saisissez votre adresse e-mail et nous vous enverrons un lien de connexion à usage unique.",
     "magic_unavailable": "La connexion par e-mail n'est pas disponible sur ce serveur.",
     "passwords_match": "Les mots de passe correspondent",
-    "sign_in": "Se connecter"
+    "sign_in": "Se connecter",
+    "login_error_title": "Échec de la connexion",
+    "login_error_back_to_login": "Retour à la connexion",
+    "login_error_auto_link_disabled": "Ce serveur ne relie pas automatiquement les comptes SSO. Connectez-vous avec vos identifiants existants, puis reliez SSO depuis votre profil.",
+    "login_error_auto_link_email_not_verified": "Votre fournisseur SSO n'a pas confirmé votre adresse e-mail. Vérifiez votre e-mail chez votre fournisseur d'identité, puis réessayez.",
+    "login_error_already_linked_elsewhere": "Un compte local avec cette adresse e-mail existe déjà et est relié à une autre identité SSO. Contactez votre administrateur.",
+    "login_error_callback_denied": "Votre lien de connexion a expiré ou a déjà été utilisé. Veuillez réessayer.",
+    "login_error_callback_failed": "La connexion SSO n'a pas pu se terminer. Veuillez réessayer.",
+    "login_error_generic": "La connexion SSO a été refusée. Veuillez réessayer."
   },
   "storage": {
     "title": "Stockage",
@@ -1009,7 +1017,18 @@
     "photo_save_failed": "Failed to save photo",
     "photo_no_file": "Please select a file first",
     "photo_managed_by_oidc": "Photo managed by your identity provider.",
-    "password_mismatch": "Les mots de passe ne correspondent pas"
+    "password_mismatch": "Les mots de passe ne correspondent pas",
+    "sso_connect_title": "Connecter l'authentification unique",
+    "sso_connect_description": "Reliez votre compte à {{provider}} pour vous connecter via SSO au lieu du mot de passe.",
+    "sso_connect_button": "Se connecter avec {{provider}}",
+    "sso_disconnect_title": "Authentification unique",
+    "sso_disconnect_description": "Votre compte est connecté à {{provider}}. Le déconnecter vous obligera à utiliser votre mot de passe pour vous connecter.",
+    "sso_disconnect_button": "Déconnecter l'authentification unique",
+    "sso_disconnect_confirm_title": "Déconnecter l'authentification unique ?",
+    "sso_disconnect_confirm_message": "Vous ne pourrez plus vous connecter qu'avec votre mot de passe ou vos identifiants OPAQUE.",
+    "sso_disconnect_confirm_button": "Déconnecter",
+    "sso_unlinked_success": "Authentification unique déconnectée.",
+    "sso_unlink_no_alt_auth": "Définissez d'abord un mot de passe — sinon vous seriez verrouillé hors de votre compte."
   },
   "upload": {
     "uploading": "Téléchargement en cours...",

--- a/migrations/20261010000000_federation_identity_rename.sql
+++ b/migrations/20261010000000_federation_identity_rename.sql
@@ -1,0 +1,44 @@
+-- Phase A of the federation-identity rename (see docs/plan/ocm.md § Schema rename).
+--
+-- Prepares the identity model to accommodate OCM + IndieAuth + OpenID Federation
+-- alongside today's single-strategy OIDC surface. Nothing about VALUES changes in
+-- this migration; the rename is pure and the new `federation_kind` column is
+-- backfilled deterministically from the presence of the existing OIDC columns.
+--
+-- Value semantics (`federation_issuer` still holds the display-name label today,
+-- not the true `iss` URL) are corrected in Phase B — see plan doc. Ship this
+-- first so the schema shape is stable before that value migration.
+--
+-- Rollback: DROP the federation_kind column; the RENAMEd columns keep working
+-- with pre-rename code paths because their values are untouched.
+
+ALTER TABLE auth.users RENAME COLUMN oidc_provider TO federation_issuer;
+ALTER TABLE auth.users RENAME COLUMN oidc_subject  TO federation_subject;
+
+ALTER TABLE auth.users ADD COLUMN federation_kind TEXT
+    CHECK (federation_kind IN ('magic_link', 'ocm', 'oidc'));
+
+-- Backfill: existing rows with a federation_issuer set are all OIDC-linked
+-- (only the OIDC flow populated the old oidc_provider column). Anything NULL
+-- stays NULL — local / password / magic-link users don't get a kind.
+UPDATE auth.users
+   SET federation_kind = 'oidc'
+ WHERE federation_issuer IS NOT NULL;
+
+-- Swap the anti-duplicate uniqueness. Old index was keyed on
+-- (oidc_provider, oidc_subject); new one includes federation_kind so OIDC
+-- and OCM (and future IndieAuth / OpenID Federation) principals stay
+-- distinct even if their (issuer, subject) tuples collide across kinds.
+DROP INDEX IF EXISTS auth.idx_users_oidc;
+CREATE UNIQUE INDEX idx_users_federation
+    ON auth.users(federation_kind, federation_issuer, federation_subject)
+    WHERE federation_kind IS NOT NULL;
+
+COMMENT ON COLUMN auth.users.federation_kind IS
+    'Trust chain that owns this identity: oidc | ocm | magic_link. NULL for pure local users. See docs/plan/ocm.md and docs/plan/federated-login.md.';
+
+COMMENT ON COLUMN auth.users.federation_issuer IS
+    'Authority that mints the subject id. OIDC: iss URL. OCM: peer domain. Magic-link: NULL. NOTE: legacy rows may still hold the OXICLOUD_OIDC_PROVIDER_NAME display label; Phase B of the federation-identity rename backfills these to real issuer URLs.';
+
+COMMENT ON COLUMN auth.users.federation_subject IS
+    'Stable identifier for this user within the federation_issuer. OIDC: sub claim (stable per RFC 7519 §4.1.2). OCM: federated address (protocol has no separate stable id in 1.1). Magic-link: NULL.';

--- a/migrations/20261011000000_users_normalized_email_index.sql
+++ b/migrations/20261011000000_users_normalized_email_index.sql
@@ -1,0 +1,44 @@
+-- Identity-lookup email column + b-tree index. Powers
+-- `list_users_by_normalized_email`, the auto-link ambiguity detector
+-- added alongside the OIDC-linking work
+-- (see docs/plan/oidc-account-linking.md § Auto-link).
+--
+-- Normalization matches `common::text::normalize_email_for_link`:
+-- lowercase + strip `+alias` sub-addressing from the local part.
+-- Unconditional storage: every row carries the normalized form, even
+-- when it equals `email`. The alternative (only populate when the
+-- normalized form differs, then `WHERE email = $1 OR
+-- identity_lookup_email = $1`) saves a few bytes per row but forces
+-- a two-branch lookup on every call. Storage cost is minimal
+-- (~30 bytes/user); simplicity of the always-populated lookup wins.
+--
+-- Storing the normalized form as its own column (rather than doing
+-- the computation in the WHERE clause) buys three things:
+--   1. Plain-equality SQL — the lookup is a one-liner, not a
+--      SPLIT_PART/LOWER expression tree that's easy to mis-copy.
+--   2. Debuggable — operators can `SELECT username, email,
+--      identity_lookup_email FROM auth.users` and immediately see
+--      why two users collide under normalization.
+--   3. Automatic — GENERATED ALWAYS AS ... STORED means PostgreSQL
+--      itself keeps the column in sync on every INSERT/UPDATE of
+--      `email`. No trigger, no application code, no drift risk.
+--
+-- Table rewrite cost: ALTER TABLE ADD COLUMN with a GENERATED
+-- expression forces a full-table rewrite (each row needs the
+-- computed value stored). Brief, exclusive lock. Fine at OxiCloud's
+-- expected sizes (self-hosted, hundreds to tens of thousands of
+-- users); would need a batched backfill on a million-row deployment.
+ALTER TABLE auth.users
+ADD COLUMN identity_lookup_email TEXT
+GENERATED ALWAYS AS (
+    LOWER(
+        SPLIT_PART(SPLIT_PART(email, '@', 1), '+', 1)
+        || '@'
+        || SPLIT_PART(email, '@', 2)
+    )
+) STORED;
+
+-- Regular b-tree index on the stored column. O(log n) probes for the
+-- auto-link ambiguity check on the OIDC callback path.
+CREATE INDEX idx_users_identity_lookup_email
+    ON auth.users(identity_lookup_email);

--- a/scripts/bulk_translate.mjs
+++ b/scripts/bulk_translate.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+// Bulk-translate missing locale keys via Lingva (public Google-Translate
+// proxy, no auth required). Pairs with `scripts/check-locales.mjs`:
+// check-locales detects the gap, this script fills it.
+//
+//   node scripts/bulk_translate.mjs
+//   node scripts/check-locales.mjs   # verify
+//
+// Idempotent — only translates keys missing in each locale, AND
+// retries any "suspicious" keys where the stored translation equals
+// the English source (Lingva passing strings through unchanged).
+//
+// Design notes:
+// - Sentinels: `{{placeholder}}` tokens are frozen as private-use
+//   unicode chars (U+E000 + index). MT engines pass them through
+//   unchanged because no language model maps them, surviving any
+//   word reordering the engine performs.
+// - Checkpointing: writes every 50 keys so a network blip loses at
+//   most the last batch instead of the whole locale.
+// - No English fallback on failure: failed keys are left absent so
+//   a re-run picks them up (no silent English bleed).
+// - `LINGVA_HOST=https://lingva.example.com node scripts/bulk_translate.mjs`
+//   lets you point at a self-hosted mirror if the public one goes
+//   down. (Lingva.ml has occasional 502s; the script retries with
+//   exponential backoff.)
+
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const LOCALES_DIR = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'frontend',
+    'static',
+    'locales'
+);
+const LINGVA = process.env.LINGVA_HOST || 'https://lingva.ml';
+const THROTTLE_MS = 150;
+const RETRIES = 4;
+const RETRY_BACKOFF_MS = 800;
+
+const LOCALE_TO_LINGVA = {
+    ar: 'ar',
+    de: 'de',
+    es: 'es',
+    fa: 'fa',
+    fr: 'fr',
+    hi: 'hi',
+    it: 'it',
+    ja: 'ja',
+    ko: 'ko',
+    nl: 'nl',
+    pl: 'pl',
+    pt: 'pt',
+    ru: 'ru',
+    zh: 'zh',
+    'zh-TW': 'zh_HANT'
+};
+const SKIP = new Set(['en']);
+
+function flat(obj, prefix = '', out = {}) {
+    for (const [k, v] of Object.entries(obj)) {
+        const key = prefix ? `${prefix}.${k}` : k;
+        if (v && typeof v === 'object' && !Array.isArray(v)) flat(v, key, out);
+        else out[key] = v;
+    }
+    return out;
+}
+
+function setNested(obj, dottedKey, value) {
+    const parts = dottedKey.split('.');
+    let cur = obj;
+    for (let i = 0; i < parts.length - 1; i++) {
+        const k = parts[i];
+        if (cur[k] === undefined || typeof cur[k] !== 'object' || Array.isArray(cur[k])) {
+            cur[k] = {};
+        }
+        cur = cur[k];
+    }
+    cur[parts[parts.length - 1]] = value;
+}
+
+// Private-use unicode sentinels: U+E000 + index encoded as code point.
+// MT engines pass them through unchanged because they have no glyphs and
+// no language model maps them. Each placeholder gets its own char so
+// reordering still works (we restore by char, not by position).
+function freezePlaceholders(text) {
+    const placeholders = [];
+    const frozen = text.replace(/\{\{([^}]+)\}\}/g, (_, name) => {
+        const idx = placeholders.length;
+        placeholders.push(name);
+        return String.fromCodePoint(0xe000 + idx);
+    });
+    return { frozen, placeholders };
+}
+function thawPlaceholders(text, placeholders) {
+    // Iterate over code points so multi-byte chars match correctly.
+    let out = '';
+    for (const ch of text) {
+        const cp = ch.codePointAt(0);
+        if (cp >= 0xe000 && cp < 0xe000 + placeholders.length) {
+            out += `{{${placeholders[cp - 0xe000]}}}`;
+        } else {
+            out += ch;
+        }
+    }
+    return out;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function translate(text, targetLang) {
+    const { frozen, placeholders } = freezePlaceholders(text);
+    const url = `${LINGVA}/api/v1/en/${targetLang}/${encodeURIComponent(frozen)}`;
+    let lastErr;
+    for (let attempt = 0; attempt < RETRIES; attempt++) {
+        try {
+            const res = await fetch(url, {
+                headers: { 'User-Agent': 'oxicloud-i18n-fill' }
+            });
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const json = await res.json();
+            const out = json.translation;
+            if (!out || typeof out !== 'string') throw new Error('no translation field');
+            return thawPlaceholders(out, placeholders);
+        } catch (e) {
+            lastErr = e;
+            await sleep(RETRY_BACKOFF_MS * (attempt + 1));
+        }
+    }
+    throw lastErr;
+}
+
+// Heuristic: a translation looks suspicious if it equals the source text
+// AND the source has at least one letter. Single-word brand terms
+// ("OxiCloud") are excluded — those legitimately stay identical.
+function looksUntranslated(src, translated) {
+    if (typeof src !== 'string' || typeof translated !== 'string') return false;
+    if (src !== translated) return false;
+    if (!/[a-zA-Z]/.test(src)) return false;
+    // Single CamelCase / lowercase token without spaces — likely a brand.
+    if (!/\s/.test(src)) return false;
+    return true;
+}
+
+const en = flat(JSON.parse(readFileSync(join(LOCALES_DIR, 'en.json'), 'utf8')));
+const enKeys = Object.keys(en);
+
+const localeFiles = readdirSync(LOCALES_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => f.slice(0, -5))
+    .filter((l) => !SKIP.has(l));
+
+const failures = {}; // locale -> array of {key, src, err}
+
+for (const locale of localeFiles) {
+    const lingvaCode = LOCALE_TO_LINGVA[locale];
+    if (!lingvaCode) {
+        console.error(`! no Lingva mapping for ${locale}, skipping`);
+        continue;
+    }
+    const path = join(LOCALES_DIR, `${locale}.json`);
+    const dict = JSON.parse(readFileSync(path, 'utf8'));
+    const dictFlat = flat(dict);
+
+    // Phase A: fill missing keys.
+    const missing = enKeys.filter((k) => !(k in dictFlat));
+    // Phase B: retry suspicious (en === locale) translations.
+    const suspicious = enKeys.filter((k) => k in dictFlat && looksUntranslated(en[k], dictFlat[k]));
+
+    const todo = [...missing, ...suspicious];
+    if (todo.length === 0) {
+        console.log(`✓ ${locale}: clean (missing 0, suspicious 0)`);
+        continue;
+    }
+    console.log(
+        `▶ ${locale}: ${missing.length} missing + ${suspicious.length} suspicious via Lingva (${lingvaCode})`
+    );
+
+    failures[locale] = [];
+    let done = 0;
+    let writeCheckpoint = 0;
+    for (const k of todo) {
+        const src = en[k];
+        if (typeof src !== 'string') {
+            done++;
+            continue;
+        }
+        try {
+            const translated = await translate(src, lingvaCode);
+            // Re-check: did Lingva just hand back the English unchanged?
+            if (looksUntranslated(src, translated)) {
+                failures[locale].push({ key: k, src, err: 'identical_to_source' });
+            }
+            setNested(dict, k, translated);
+            done++;
+        } catch (e) {
+            failures[locale].push({ key: k, src, err: e.message });
+            // Don't write English fallback — leave the key absent so the
+            // next run picks it up. (For suspicious-retries, the existing
+            // suspect value stays in place.)
+            done++;
+        }
+
+        // Persist progress every 50 keys so a network blip doesn't lose
+        // everything translated so far.
+        if (done - writeCheckpoint >= 50) {
+            writeFileSync(path, JSON.stringify(dict, null, 2) + '\n');
+            writeCheckpoint = done;
+            console.log(`  ${locale}: ${done}/${todo.length} (checkpoint)`);
+        }
+        await sleep(THROTTLE_MS);
+    }
+    writeFileSync(path, JSON.stringify(dict, null, 2) + '\n');
+    console.log(
+        `✓ ${locale}: ${done}/${todo.length} processed, ${failures[locale].length} unresolved`
+    );
+}
+
+const totalUnresolved = Object.values(failures).reduce((n, arr) => n + arr.length, 0);
+if (totalUnresolved > 0) {
+    console.log(`\nUnresolved: ${totalUnresolved}`);
+    for (const [loc, arr] of Object.entries(failures)) {
+        if (arr.length === 0) continue;
+        console.log(`  ${loc}: ${arr.length}`);
+        for (const f of arr.slice(0, 5)) {
+            console.log(`    ${f.key} (${f.err}): "${f.src.slice(0, 50)}"`);
+        }
+        if (arr.length > 5) console.log(`    … +${arr.length - 5} more`);
+    }
+}
+console.log('\nDone.');

--- a/src/application/adapters/plugin_user_lifecycle_hook.rs
+++ b/src/application/adapters/plugin_user_lifecycle_hook.rs
@@ -110,8 +110,9 @@ mod tests {
             "alice@example.com".to_string(),
             Some("alice".to_string()),
             None,
-            None,
-            None,
+            None, // federation_kind
+            None, // federation_issuer
+            None, // federation_subject
             UserRole::User,
             0,
             false,
@@ -152,8 +153,9 @@ mod tests {
             "bob@example.com".to_string(),
             None,
             None,
-            None,
-            None,
+            None, // federation_kind
+            None, // federation_issuer
+            None, // federation_subject
             UserRole::User,
             0,
             false,

--- a/src/application/dtos/user_dto.rs
+++ b/src/application/dtos/user_dto.rs
@@ -131,7 +131,7 @@ pub struct AdminUserSummaryDto {
     pub is_external: bool,
     /// TRUE when the user has a server-verifiable password on file
     /// (`password_hash IS NOT NULL`). The admin table uses this
-    /// alongside `oidc_provider` and `opaque_registered` to render
+    /// alongside `federation_issuer` and `opaque_registered` to render
     /// the user's full capability set: a `password` chip lights up
     /// here, an OIDC provider name renders the SSO badge, an
     /// envelope-on-file flips the OPAQUE chip. A user with none of
@@ -171,7 +171,7 @@ impl From<UserListEntry> for AdminUserSummaryDto {
             storage_used_bytes: entry.storage_used_bytes,
             last_login_at: entry.last_login_at,
             active: entry.active,
-            auth_provider: entry.oidc_provider.unwrap_or_else(|| "local".to_string()),
+            auth_provider: entry.federation_issuer.unwrap_or_else(|| "local".to_string()),
             is_external: entry.is_external,
             has_password: entry.has_password,
             opaque_registered: entry.opaque_registered,
@@ -208,7 +208,7 @@ impl From<User> for UserDto {
             last_login_at: p.last_login_at,
             active: p.active,
             // Some(provider) moves the String; None still allocates "local".
-            auth_provider: p.oidc_provider.unwrap_or_else(|| "local".to_string()),
+            auth_provider: p.federation_issuer.unwrap_or_else(|| "local".to_string()),
             image: p.image,
             can_edit_image,
             is_external: p.is_external,

--- a/src/application/dtos/user_dto.rs
+++ b/src/application/dtos/user_dto.rs
@@ -25,7 +25,36 @@ pub struct UserDto {
     pub updated_at: DateTime<Utc>,
     pub last_login_at: Option<DateTime<Utc>>,
     pub active: bool,
-    pub auth_provider: String,
+    /// Which trust chain minted this user's federation identity —
+    /// `"oidc" | "ocm" | "magic_link"` — or `None` for pure local
+    /// users. Load-bearing for "is this user OIDC?"-shape predicates:
+    /// use `federation_kind == "oidc"` rather than string-scraping
+    /// `federation_issuer`. Serialized only when populated.
+    ///
+    /// Mirrors `auth.users.federation_kind` verbatim — same name at
+    /// DB, entity, and wire layers so there's no translation to reason
+    /// about. See docs/plan/ocm.md § Identity & auth model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub federation_kind: Option<String>,
+    /// The authority that mints this user's `federation_subject` —
+    /// issuer URL for OIDC (id_token `iss` claim), peer domain for
+    /// OCM, `null` for local users (password / OPAQUE only).
+    ///
+    /// Renamed from `auth_provider` (which was a `String` with the
+    /// sentinel `"local"` for non-federated users, and a human-readable
+    /// label like `"MockSSO"` before Phase B). This shape mirrors the
+    /// `auth.users.federation_issuer` column directly: nullable when
+    /// there's no federation involved. FE predicates for "is this user
+    /// federated?" should read `federation_kind`, not
+    /// string-compare this value.
+    ///
+    /// When populated, FE code that wants a friendly display label
+    /// looks this value up against `OidcProviderInfoDto.issuer →
+    /// provider_name` to render the deployment's configured display
+    /// name; falls back to the raw issuer for foreign IdPs / legacy
+    /// rows still holding a pre-Phase-B label.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub federation_issuer: Option<String>,
     pub image: Option<String>,
     pub can_edit_image: bool,
     /// `true` for grant-only external recipients (magic-link, OIDC-only,
@@ -95,8 +124,8 @@ pub struct UserDto {
     #[serde(default)]
     pub force_password_change: bool,
     /// TRUE when the account has a local Argon2id `password_hash` on
-    /// file. Distinct from `auth_provider`: an SSO-linked account
-    /// (auth_provider != "local") can ALSO carry a local password if
+    /// file. Distinct from `federation_kind`: an OIDC-linked account
+    /// (`federation_kind == "oidc"`) can ALSO carry a local password if
     /// it was set at signup or later — a hybrid posture. The SPA
     /// gates the profile page's change-password card on this flag,
     /// so hybrid users can rotate their local password even though
@@ -127,7 +156,12 @@ pub struct AdminUserSummaryDto {
     pub storage_used_bytes: i64,
     pub last_login_at: Option<DateTime<Utc>>,
     pub active: bool,
-    pub auth_provider: String,
+    /// See `UserDto::federation_kind` — same semantics, same wire spelling.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub federation_kind: Option<String>,
+    /// See `UserDto::federation_issuer` — same semantics, same wire spelling.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub federation_issuer: Option<String>,
     pub is_external: bool,
     /// TRUE when the user has a server-verifiable password on file
     /// (`password_hash IS NOT NULL`). The admin table uses this
@@ -171,7 +205,8 @@ impl From<UserListEntry> for AdminUserSummaryDto {
             storage_used_bytes: entry.storage_used_bytes,
             last_login_at: entry.last_login_at,
             active: entry.active,
-            auth_provider: entry.federation_issuer.unwrap_or_else(|| "local".to_string()),
+            federation_kind: entry.federation_kind,
+            federation_issuer: entry.federation_issuer,
             is_external: entry.is_external,
             has_password: entry.has_password,
             opaque_registered: entry.opaque_registered,
@@ -207,8 +242,11 @@ impl From<User> for UserDto {
             updated_at: p.updated_at,
             last_login_at: p.last_login_at,
             active: p.active,
-            // Some(provider) moves the String; None still allocates "local".
-            auth_provider: p.federation_issuer.unwrap_or_else(|| "local".to_string()),
+            // NULL on both fields for local users (no federation wired).
+            // FE predicates use `!!federation_kind` for "is federated?" —
+            // no "local" sentinel string; the null tells the whole story.
+            federation_kind: p.federation_kind.map(|k| k.as_str().to_string()),
+            federation_issuer: p.federation_issuer,
             image: p.image,
             can_edit_image,
             is_external: p.is_external,
@@ -467,6 +505,22 @@ pub struct OidcExchangeDto {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct OidcProviderInfoDto {
     pub enabled: bool,
+    /// The authoritative issuer URL for THIS deployment's OIDC config —
+    /// same value that lands on `auth.users.federation_issuer` for
+    /// users JIT-provisioned via this IdP.
+    ///
+    /// Populated so the frontend can resolve display: when
+    /// `UserDto.federation_issuer` equals this `issuer`, render
+    /// `provider_name` as the human-friendly label (avoids showing raw
+    /// issuer URLs like `https://sso.example.com/realms/main` in the
+    /// admin badge / profile view). Falls back to the raw issuer when
+    /// there's no match — happens for legacy rows not yet lazy-rebound,
+    /// or (future) users linked to a different IdP than the currently
+    /// configured one.
+    ///
+    /// Empty string when OIDC is disabled on this deployment.
+    #[serde(default)]
+    pub issuer: String,
     pub provider_name: String,
     pub authorize_endpoint: String,
     pub password_login_enabled: bool,

--- a/src/application/ports/auth_ports.rs
+++ b/src/application/ports/auth_ports.rs
@@ -109,6 +109,14 @@ pub trait UserStoragePort: Send + Sync + 'static {
     /// Gets a user by email
     async fn get_user_by_email(&self, email: &str) -> Result<User, DomainError>;
 
+    /// Returns every user whose email normalizes to `normalized_email`
+    /// (see `UserRepository::list_users_by_normalized_email` for the
+    /// full contract and the auto-link ambiguity-detection use case).
+    async fn list_users_by_normalized_email(
+        &self,
+        normalized_email: &str,
+    ) -> Result<Vec<User>, DomainError>;
+
     /// Updates an existing user
     async fn update_user(&self, user: User) -> Result<User, DomainError>;
 

--- a/src/application/ports/auth_ports.rs
+++ b/src/application/ports/auth_ports.rs
@@ -193,6 +193,43 @@ pub trait UserStoragePort: Send + Sync + 'static {
         new_issuer: &str,
     ) -> Result<(), DomainError>;
 
+    /// Attach a federation identity to a user row that currently has
+    /// none. Used by the self-service link flow and the auto-link
+    /// branch of the OIDC callback. See
+    /// docs/plan/oidc-account-linking.md.
+    ///
+    /// Enforces at the DB layer via the
+    /// `idx_users_federation` UNIQUE index: if this triple is already
+    /// bound to a DIFFERENT user, returns `AlreadyExists`. The caller
+    /// (app service) translates that to a `already_linked_elsewhere`
+    /// audit reason and a user-facing refusal.
+    ///
+    /// Does NOT overwrite an already-linked identity — the current
+    /// user must be unlinked first. This is a "first link" primitive
+    /// only; the app service's higher-level `link_oidc` orchestrates
+    /// the pre-checks (idempotent-if-same / refuse-if-different).
+    async fn link_federation_identity(
+        &self,
+        user_id: Uuid,
+        kind: &str,
+        issuer: &str,
+        subject: &str,
+    ) -> Result<(), DomainError>;
+
+    /// Scalar `opaque_envelope IS NOT NULL` for the user. Used by the
+    /// unlink refusal guard (a user with an OPAQUE envelope still has
+    /// a working direct login even after OIDC unlink). Avoids
+    /// dragging the full envelope bytes across the wire for a bool.
+    async fn is_opaque_registered(&self, user_id: Uuid) -> Result<bool, DomainError>;
+
+    /// Detach the current federation identity from a user row: set all
+    /// three federation columns to NULL. The `has_password` or
+    /// `opaque_registered` fallback guard lives at the app service
+    /// layer — this method is a mechanical UPDATE.
+    ///
+    /// Idempotent: calling on an already-unlinked user is a no-op.
+    async fn unlink_federation_identity(&self, user_id: Uuid) -> Result<(), DomainError>;
+
     /// Lists users by role (e.g., "admin" or "user")
     async fn list_users_by_role(&self, role: &str) -> Result<Vec<User>, DomainError>;
 

--- a/src/application/ports/auth_ports.rs
+++ b/src/application/ports/auth_ports.rs
@@ -179,6 +179,20 @@ pub trait UserStoragePort: Send + Sync + 'static {
         image: Option<&str>,
     ) -> Result<(), DomainError>;
 
+    /// Federation-identity Phase B lazy rebind: overwrite `federation_issuer`
+    /// on a specific user row. Called when an OIDC login's id_token `iss`
+    /// claim proves the stored value (typically a legacy display label) is
+    /// out of sync with the true issuer URL. Guarded (`IS DISTINCT FROM`)
+    /// so calling with the current value is a zero-write no-op.
+    ///
+    /// Audit signal for the rebind lives at the caller (auth service) —
+    /// this repo method just moves the column value.
+    async fn rebind_federation_issuer(
+        &self,
+        user_id: Uuid,
+        new_issuer: &str,
+    ) -> Result<(), DomainError>;
+
     /// Lists users by role (e.g., "admin" or "user")
     async fn list_users_by_role(&self, role: &str) -> Result<Vec<User>, DomainError>;
 
@@ -238,6 +252,15 @@ pub struct OidcTokenSet {
 #[derive(Debug, Clone)]
 pub struct OidcIdClaims {
     pub sub: String,
+    /// The validated `iss` claim from the id_token. Equal to
+    /// `discovery.issuer` (the validator enforces `iss == discovery.issuer`,
+    /// so this is a safe echo of the authoritative issuer URL).
+    ///
+    /// Load-bearing for the federation-identity Phase B lazy-rebind: the
+    /// app service compares this against `user.federation_issuer` and
+    /// updates the row when the stored value is still a legacy display
+    /// label (see docs/plan/ocm.md § Rename PR — Phase B).
+    pub iss: String,
     pub email: Option<String>,
     pub email_verified: Option<bool>,
     pub preferred_username: Option<String>,
@@ -275,6 +298,17 @@ pub struct OidcLogoutClaims {
     /// JWT identifier — used by the app service to prevent replay of the
     /// same logout_token within the token's freshness window.
     pub jti: Option<String>,
+    /// The validated `iss` claim from the logout_token — echoed from
+    /// `discovery.issuer` (the validator enforces `iss == discovery.issuer`,
+    /// so this is a safe echo of the authoritative issuer URL).
+    ///
+    /// Load-bearing for the sub-based revocation path (BCL without sid):
+    /// the app service passes this to
+    /// `revoke_user_sessions_by_federation_subject(issuer, sub)`, and the
+    /// pg impl matches on `auth.users.federation_issuer` — which post
+    /// Phase B stores the iss URL, NOT the display label. Passing the
+    /// display label (via `oidc.provider_name()`) misses every row.
+    pub iss: String,
 }
 
 /// Port for OIDC operations — implemented in infrastructure layer

--- a/src/application/ports/auth_ports.rs
+++ b/src/application/ports/auth_ports.rs
@@ -194,10 +194,14 @@ pub trait UserStoragePort: Send + Sync + 'static {
     /// Changes a user's password
     async fn change_password(&self, user_id: Uuid, password_hash: &str) -> Result<(), DomainError>;
 
-    /// Finds a user by OIDC provider + subject pair
-    async fn get_user_by_oidc_subject(
+    /// Finds a user by federation (issuer, subject) pair. Historically
+    /// called for OIDC lookups (the only federation kind in-tree at rename
+    /// time); after Phase B/C of the federation-identity rename the
+    /// caller passes the true `iss` URL rather than a display label. See
+    /// `docs/plan/ocm.md § Schema rename` for the transition.
+    async fn get_user_by_federation_subject(
         &self,
-        provider: &str,
+        issuer: &str,
         subject: &str,
     ) -> Result<User, DomainError>;
 
@@ -383,12 +387,12 @@ pub trait SessionStoragePort: Send + Sync + 'static {
 
     /// OIDC Back-Channel Logout fallback when the IdP didn't supply a `sid`:
     /// revoke every session belonging to the user identified by
-    /// `(oidc_provider, oidc_subject)`. Returns the affected user id, or
-    /// `None` if we don't know that user.
-    async fn revoke_user_sessions_by_oidc_subject(
+    /// `(federation_issuer, federation_subject)`. Returns the affected
+    /// user id, or `None` if we don't know that user.
+    async fn revoke_user_sessions_by_federation_subject(
         &self,
-        oidc_provider: &str,
-        oidc_subject: &str,
+        issuer: &str,
+        subject: &str,
     ) -> Result<Option<Uuid>, DomainError>;
 }
 

--- a/src/application/services/admin_settings_service.rs
+++ b/src/application/services/admin_settings_service.rs
@@ -53,6 +53,10 @@ impl AdminSettingsService {
             ("OXICLOUD_OIDC_CLIENT_SECRET", "client_secret"),
             ("OXICLOUD_OIDC_SCOPES", "scopes"),
             ("OXICLOUD_OIDC_AUTO_PROVISION", "auto_provision"),
+            (
+                "OXICLOUD_OIDC_AUTO_LINK_EMAIL_MATCH",
+                "auto_link_email_match",
+            ),
             ("OXICLOUD_OIDC_ADMIN_GROUPS", "admin_groups"),
             (
                 "OXICLOUD_OIDC_DISABLE_PASSWORD_LOGIN",
@@ -94,6 +98,9 @@ impl AdminSettingsService {
         }
         if std::env::var("OXICLOUD_OIDC_AUTO_PROVISION").is_ok() {
             config.auto_provision = e.auto_provision;
+        }
+        if std::env::var("OXICLOUD_OIDC_AUTO_LINK_EMAIL_MATCH").is_ok() {
+            config.auto_link_email_match = e.auto_link_email_match;
         }
         if std::env::var("OXICLOUD_OIDC_ADMIN_GROUPS").is_ok() {
             config.admin_groups = e.admin_groups.clone();
@@ -141,6 +148,10 @@ impl AdminSettingsService {
                 .get("oidc.provider_name")
                 .cloned()
                 .unwrap_or(d.provider_name),
+            auto_link_email_match: db
+                .get("oidc.auto_link_email_match")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(d.auto_link_email_match),
         };
 
         // Env vars override DB

--- a/src/application/services/auth_application_service.rs
+++ b/src/application/services/auth_application_service.rs
@@ -3844,26 +3844,38 @@ impl AuthApplicationService {
             }
             Err(_) => {
                 // User doesn't exist by federation subject — try to
-                // match by email. Two possible outcomes:
-                //   * Email matches an existing local user AND the
-                //     auto-link decision tree accepts → auto-link,
-                //     yield the linked user (falls through to session
-                //     mint below).
-                //   * Email matches AND auto-link refuses (config off,
-                //     email not verified, already linked elsewhere) →
-                //     return "contact admin" error (self-service link
-                //     flow remains available).
-                //   * No email match → JIT provision (existing branch).
-                //
-                // NOTE (MVP scope): exact-match lookup only. If OxiCloud
-                // stores `alice+work@example.com` but the IdP returns
-                // `alice@example.com`, the exact match misses even
-                // though they normalise to the same value. The user
-                // falls through to the "contact admin" refusal and can
-                // self-serve via the profile link flow.
-                let matched_user = self.user_storage.get_user_by_email(&oidc_email).await.ok();
+                // match by email under the same normalization the
+                // self-service link flow uses (lowercase + strip
+                // `+alias`). Three possible outcomes:
+                //   * 0 matches → JIT provision (existing branch).
+                //   * 1 match  → run the auto-link decision tree.
+                //   * >1 match → refuse `email_ambiguous`. Two local
+                //     rows collapsing to the same normalized email
+                //     (`alice@example.com` + `alice+work@example.com`)
+                //     mean we can't safely pick one to auto-link;
+                //     admin must resolve.
+                let normalized = crate::common::text::normalize_email_for_link(&oidc_email);
+                let candidates = self
+                    .user_storage
+                    .list_users_by_normalized_email(&normalized)
+                    .await
+                    .unwrap_or_default();
 
-                if let Some(matched) = matched_user {
+                if candidates.len() > 1 {
+                    tracing::info!(
+                        target: "audit",
+                        event = "federation.auto_link_refused",
+                        reason = "email_ambiguous",
+                        normalized_email = %normalized,
+                        candidate_count = candidates.len(),
+                        "🔗 auto-link refused — multiple local users normalize to the IdP email",
+                    );
+                    return Ok(OidcCallbackResult::AutoLinkRefused {
+                        reason: "email_ambiguous",
+                    });
+                }
+
+                if let Some(matched) = candidates.into_iter().next() {
                     // Auto-link decision tree — see
                     // docs/plan/oidc-account-linking.md § Auto-link.
                     let can_auto_link = oidc_config.auto_link_email_match

--- a/src/application/services/auth_application_service.rs
+++ b/src/application/services/auth_application_service.rs
@@ -1516,16 +1516,19 @@ impl AuthApplicationService {
             self.backchannel_logout_jti_seen.insert(jti.clone(), ());
         }
 
-        let provider_name = oidc.provider_name().to_string();
-
         // Resolve which sessions to revoke.
         let affected_user_ids: Vec<Uuid> = if let Some(sid) = claims.sid.as_ref() {
             self.session_storage
                 .revoke_sessions_by_oidc_sid(sid)
                 .await?
         } else if let Some(sub) = claims.sub.as_ref() {
+            // Pass claims.iss (the id_token's real issuer URL from the
+            // logout_token), NOT the OIDC service's provider_name
+            // display label. Post Phase B of the federation-identity
+            // rename, `auth.users.federation_issuer` stores the iss
+            // URL — matching on the display label misses every row.
             self.session_storage
-                .revoke_user_sessions_by_federation_subject(&provider_name, sub)
+                .revoke_user_sessions_by_federation_subject(&claims.iss, sub)
                 .await?
                 .into_iter()
                 .collect()
@@ -3396,13 +3399,63 @@ impl AuthApplicationService {
             .clone()
             .unwrap_or_else(|| format!("{}@oidc.local", oidc_username));
 
-        // 5. Look up existing user by OIDC subject
-        let user = match self
+        // 5. Look up existing user by OIDC subject.
+        //
+        // Two-step lookup implements the Phase B lazy-rebind of the
+        // federation-identity rename (docs/plan/ocm.md § Phase B):
+        //   1. Canonical lookup keyed on the id_token's real `iss` claim.
+        //      Post-migration this is what every fresh JIT row uses.
+        //   2. Legacy fallback keyed on the OXICLOUD_OIDC_PROVIDER_NAME
+        //      display label. Fires for rows minted before the rename.
+        //      If the fallback hits, the row is rebound to the real iss
+        //      before this branch returns — first login after upgrade
+        //      self-heals the user; no admin action needed.
+        // If both miss, JIT provisioning kicks in below and writes the
+        // canonical value from the start.
+        let canonical = self
             .user_storage
-            .get_user_by_federation_subject(&provider_name, &claims.sub)
-            .await
-        {
+            .get_user_by_federation_subject(&claims.iss, &claims.sub)
+            .await;
+        let lookup_result = match canonical {
+            Ok(u) => Ok(u),
+            // Only fall through to the legacy lookup if the canonical one
+            // said "not found" — treat all OTHER errors as fatal to avoid
+            // masking DB failures with a lookup that would probably fail
+            // the same way. NotFound is the only benign case here.
+            Err(e) if e.kind == ErrorKind::NotFound => {
+                self.user_storage
+                    .get_user_by_federation_subject(&provider_name, &claims.sub)
+                    .await
+            }
+            Err(e) => Err(e),
+        };
+        let user = match lookup_result {
             Ok(mut existing_user) => {
+                // Lazy-rebind: if the row's stored issuer doesn't match
+                // the real iss claim, update it now. Covers the legacy-
+                // label case (fallback hit) AND any drift accumulated
+                // during Phase A when JIT was still writing labels.
+                // rebind_federation_issuer is a guarded UPDATE — same-value
+                // no-op costs nothing.
+                if existing_user.federation_issuer() != Some(claims.iss.as_str()) {
+                    let old = existing_user
+                        .federation_issuer()
+                        .map(str::to_string)
+                        .unwrap_or_default();
+                    self.user_storage
+                        .rebind_federation_issuer(existing_user.id(), &claims.iss)
+                        .await?;
+                    tracing::info!(
+                        target: "audit",
+                        event = "federation.issuer_rebound",
+                        reason = "lazy_backfill",
+                        user_id = %existing_user.id(),
+                        federation_kind = "oidc",
+                        old_issuer = %old,
+                        new_issuer = %claims.iss,
+                        "🔗 federation_issuer rebound from legacy label to true iss URL",
+                    );
+                }
                 // User exists — dispatch login BEFORE register_login() so
                 // hooks observe `last_login_at = None` on the very first
                 // login (see tip #1 in the trait docstring).
@@ -3516,14 +3569,12 @@ impl AuthApplicationService {
                     Some(username.clone()),
                     None,
                     Some(crate::domain::entities::user::FederationKind::Oidc),
-                    // TODO Phase B: `provider_name` still carries the
-                    // OXICLOUD_OIDC_PROVIDER_NAME display label instead
-                    // of the true `iss` URL. Lazy-rebind on subsequent
-                    // logins converts the row (see docs/plan/ocm.md
-                    // § Rename PR — Phase B). First-login value is the
-                    // label for backwards compatibility with existing
-                    // rows.
-                    Some(provider_name.clone()),
+                    // Phase B canonical value: the id_token's real `iss`
+                    // claim (validated to equal discovery.issuer in
+                    // OidcService). No more display-label writes at JIT —
+                    // legacy rows are fixed via lazy rebind in the
+                    // existing-user branch above.
+                    Some(claims.iss.clone()),
                     Some(claims.sub.clone()),
                     role,
                     quota,

--- a/src/application/services/auth_application_service.rs
+++ b/src/application/services/auth_application_service.rs
@@ -56,6 +56,14 @@ pub enum OidcCallbackResult {
     /// `/profile?link_error=<reason>` redirect. See
     /// docs/plan/oidc-account-linking.md § Safety checks.
     LinkRefused { reason: &'static str },
+    /// Auto-link decision refused during the OIDC LOGIN callback path
+    /// (existing local user matched by email but the decision tree
+    /// rejected). `reason` is one of `auto_link_disabled`,
+    /// `auto_link_email_not_verified`, `already_linked_elsewhere`;
+    /// the handler maps each to a distinct CamelCase `error_type`
+    /// on the 409 response so the login page can switch on it.
+    /// See docs/plan/oidc-account-linking.md § Auto-link.
+    AutoLinkRefused { reason: &'static str },
 }
 
 /// Outcome of a successful magic-link redemption. The auth tokens are
@@ -3877,14 +3885,15 @@ impl AuthApplicationService {
                             reason = reason,
                             "🔗 auto-link refused",
                         );
-                        return Err(DomainError::new(
-                            ErrorKind::AlreadyExists,
-                            "OIDC",
-                            format!(
-                                "A user with email '{}' already exists. Contact admin to link your OIDC identity.",
-                                oidc_email
-                            ),
-                        ));
+                        // Ok(AutoLinkRefused) rather than Err(AlreadyExists)
+                        // so the handler can map each reason to a distinct
+                        // stable CamelCase error_type (AutoLinkDisabled /
+                        // AutoLinkEmailNotVerified / AutoLinkAlreadyLinked-
+                        // Elsewhere). Bubbling as a generic AlreadyExists
+                        // would collapse all three reasons into "Already
+                        // Exists" on the wire and leave the SPA without a
+                        // switch arm for user-facing copy.
+                        return Ok(OidcCallbackResult::AutoLinkRefused { reason });
                     }
 
                     // All checks passed — commit the auto-link, re-fetch

--- a/src/application/services/auth_application_service.rs
+++ b/src/application/services/auth_application_service.rs
@@ -560,8 +560,9 @@ impl AuthApplicationService {
             dto.email.clone(),
             dto.username.clone(),
             password_hash,
-            None,
-            None,
+            None, // federation_kind: local password registration
+            None, // federation_issuer
+            None, // federation_subject
             role,
             quota,
             false,
@@ -662,8 +663,9 @@ impl AuthApplicationService {
             email,
             Some(username.clone()),
             Some(password_hash),
-            None,
-            None,
+            None, // federation_kind: setup admin is local
+            None, // federation_issuer
+            None, // federation_subject
             role,
             quota,
             false,
@@ -1523,7 +1525,7 @@ impl AuthApplicationService {
                 .await?
         } else if let Some(sub) = claims.sub.as_ref() {
             self.session_storage
-                .revoke_user_sessions_by_oidc_subject(&provider_name, sub)
+                .revoke_user_sessions_by_federation_subject(&provider_name, sub)
                 .await?
                 .into_iter()
                 .collect()
@@ -2810,8 +2812,9 @@ impl AuthApplicationService {
                 email,
                 Some(dto.username.clone()),
                 Some(password_hash),
-                None,
-                None,
+                None, // federation_kind: admin-created external, no federation link yet
+                None, // federation_issuer
+                None, // federation_subject
                 UserRole::User,
                 0,
                 true,
@@ -2821,8 +2824,9 @@ impl AuthApplicationService {
                 email,
                 Some(dto.username.clone()),
                 Some(password_hash),
-                None,
-                None,
+                None, // federation_kind: admin-created local user
+                None, // federation_issuer
+                None, // federation_subject
                 role,
                 quota,
                 false,
@@ -3395,7 +3399,7 @@ impl AuthApplicationService {
         // 5. Look up existing user by OIDC subject
         let user = match self
             .user_storage
-            .get_user_by_oidc_subject(&provider_name, &claims.sub)
+            .get_user_by_federation_subject(&provider_name, &claims.sub)
             .await
         {
             Ok(mut existing_user) => {
@@ -3511,6 +3515,14 @@ impl AuthApplicationService {
                     oidc_email,
                     Some(username.clone()),
                     None,
+                    Some(crate::domain::entities::user::FederationKind::Oidc),
+                    // TODO Phase B: `provider_name` still carries the
+                    // OXICLOUD_OIDC_PROVIDER_NAME display label instead
+                    // of the true `iss` URL. Lazy-rebind on subsequent
+                    // logins converts the row (see docs/plan/ocm.md
+                    // § Rename PR — Phase B). First-login value is the
+                    // label for backwards compatibility with existing
+                    // rows.
                     Some(provider_name.clone()),
                     Some(claims.sub.clone()),
                     role,

--- a/src/application/services/auth_application_service.rs
+++ b/src/application/services/auth_application_service.rs
@@ -42,6 +42,20 @@ pub enum OidcCallbackResult {
         user_id: Uuid,
         username: String,
     },
+    /// Self-service link flow completed — the OIDC identity was
+    /// attached to the already-authenticated user. Handler redirects
+    /// the browser to `/profile?linked=1` (or `?link_error=<reason>`
+    /// on the `LinkRefused` variant below).
+    ///
+    /// The user's existing session cookies remain valid (no new session
+    /// is minted for the link flow — the user was already logged in
+    /// when they started).
+    LinkCompleted { user_id: Uuid },
+    /// Self-service link refused by a safety check. `reason` is the
+    /// stable enum-shaped key the handler surfaces on the
+    /// `/profile?link_error=<reason>` redirect. See
+    /// docs/plan/oidc-account-linking.md § Safety checks.
+    LinkRefused { reason: &'static str },
 }
 
 /// Outcome of a successful magic-link redemption. The auth tokens are
@@ -93,6 +107,21 @@ pub struct MagicLinkRedemption {
     pub resource_id: Option<Uuid>,
 }
 
+/// Why an OIDC flow was initiated — dispatched on at callback time.
+///
+/// `Login` (default) → normal login: JIT-provision or match existing
+/// user, mint OxiCloud session.
+///
+/// `Link { user_id }` → self-service identity link
+/// (`POST /api/auth/oidc/link/start`). The callback runs safety checks
+/// and, on success, UPDATEs `federation_*` on the ALREADY-LOGGED-IN
+/// user's row. See docs/plan/oidc-account-linking.md.
+#[derive(Clone)]
+enum FlowIntent {
+    Login,
+    Link { user_id: Uuid },
+}
+
 /// Tracks a pending OIDC authorization flow (CSRF + PKCE + nonce)
 #[derive(Clone)]
 struct PendingOidcFlow {
@@ -102,6 +131,10 @@ struct PendingOidcFlow {
     /// page. On successful callback the flow will mint an app-password and
     /// complete the Nextcloud login flow instead of issuing internal JWTs.
     nc_flow_token: Option<String>,
+    /// What the callback should DO with a successful IdP response.
+    /// Defaults to `Login` for every existing flow-mint call site;
+    /// self-service linking sets `Link { user_id }`.
+    intent: FlowIntent,
 }
 
 /// Tracks a pending one-time token exchange after successful OIDC callback
@@ -3154,6 +3187,7 @@ impl AuthApplicationService {
                 pkce_verifier,
                 nonce: nonce.clone(),
                 nc_flow_token: None,
+                intent: FlowIntent::Login,
             },
         );
 
@@ -3168,6 +3202,296 @@ impl AuthApplicationService {
         );
 
         Ok(authorize_url)
+    }
+
+    /// Prepare an OIDC authorize flow for the SELF-SERVICE LINK path.
+    /// Same PKCE + nonce dance as `prepare_oidc_authorize`, but the
+    /// pending-flow entry carries `FlowIntent::Link { user_id }` so the
+    /// callback branches to the link handler instead of the login one.
+    ///
+    /// The caller MUST have already authenticated the user (this method
+    /// takes user_id from the current session context). See
+    /// docs/plan/oidc-account-linking.md § UX flow — link.
+    pub async fn prepare_oidc_link(&self, user_id: Uuid) -> Result<String, DomainError> {
+        let oidc = self.oidc_service().ok_or_else(|| {
+            DomainError::new(
+                ErrorKind::InternalError,
+                "OIDC",
+                "OIDC service not configured",
+            )
+        })?;
+
+        // Anti-scope-creep pre-check: refuse if the user is already
+        // linked. Callers get an immediate error rather than round-
+        // tripping through the IdP just to be refused at callback time.
+        // (The callback still re-checks — this is a UX shortcut, not
+        // the source of truth.)
+        let user = self.user_storage.get_user_by_id(user_id).await?;
+        if user.federation_kind().is_some() {
+            return Err(DomainError::new(
+                ErrorKind::AlreadyExists,
+                "Federation",
+                "This user is already linked to a federation identity. \
+                 Unlink first before re-linking.",
+            ));
+        }
+
+        use rand_core::{OsRng, RngCore};
+        use sha2::{Digest, Sha256};
+
+        let mut state_bytes = [0u8; 32];
+        OsRng.fill_bytes(&mut state_bytes);
+        let state_token = hex::encode(state_bytes);
+
+        let mut nonce_bytes = [0u8; 32];
+        OsRng.fill_bytes(&mut nonce_bytes);
+        let nonce = hex::encode(nonce_bytes);
+
+        let mut verifier_bytes = [0u8; 32];
+        OsRng.fill_bytes(&mut verifier_bytes);
+        let pkce_verifier = base64_url_encode(&verifier_bytes);
+        let pkce_challenge = {
+            let hash = Sha256::digest(pkce_verifier.as_bytes());
+            base64_url_encode(&hash)
+        };
+
+        self.pending_oidc_flows.insert(
+            state_token.clone(),
+            PendingOidcFlow {
+                pkce_verifier,
+                nonce: nonce.clone(),
+                nc_flow_token: None,
+                intent: FlowIntent::Link { user_id },
+            },
+        );
+
+        let authorize_url = oidc
+            .get_authorize_url(&state_token, &nonce, &pkce_challenge)
+            .await?;
+
+        tracing::info!(
+            target: "audit",
+            event = "federation.link_started",
+            user_id = %user_id,
+            "🔗 self-service OIDC link flow initiated"
+        );
+
+        Ok(authorize_url)
+    }
+
+    /// Detach the current OIDC identity from a user. Refuses if the
+    /// user has no other authentication credential — otherwise the
+    /// user would lock themselves out of their own account.
+    ///
+    /// "Other credential" = local password OR OPAQUE envelope on file.
+    /// Magic-link doesn't count as a safe fallback: the OIDC-master
+    /// rule refuses magic-link for OIDC-linked users, so its behavior
+    /// FLIPS after unlink, creating surprise; and it depends on SMTP
+    /// wiring which may not be present. See
+    /// docs/plan/oidc-account-linking.md § Unlink refusal.
+    /// Run the safety checks + UPDATE for the self-service link flow.
+    /// Called from `oidc_callback` when `FlowIntent::Link { user_id }`
+    /// was set at flow-start time. Returns `OidcCallbackResult` variants
+    /// that the handler translates to a redirect (LinkCompleted →
+    /// `/profile?linked=1`, LinkRefused → `/profile?link_error=<key>`).
+    ///
+    /// Safety checks (all refusals are wire-visible as `link_error=`):
+    /// - Session valid — target user exists (state's user_id points to
+    ///   a real row). If not, `session_expired`.
+    /// - IdP provided an email — else `email_not_provided`.
+    /// - Emails match under normalize_email_for_link — else
+    ///   `email_mismatch`.
+    /// - Identity `(kind, iss, sub)` not already linked to a DIFFERENT
+    ///   user — else `already_linked_elsewhere`.
+    /// - Current user isn't already linked to a DIFFERENT identity —
+    ///   else `already_linked`. Same identity → idempotent success.
+    async fn complete_oidc_link(
+        &self,
+        user_id: Uuid,
+        claims: &OidcIdClaims,
+    ) -> Result<OidcCallbackResult, DomainError> {
+        use crate::common::text::normalize_email_for_link;
+
+        // 1. Session validity — the target user must still exist.
+        let user = match self.user_storage.get_user_by_id(user_id).await {
+            Ok(u) => u,
+            Err(_) => {
+                tracing::info!(
+                    target: "audit",
+                    event = "federation.link_refused",
+                    user_id = %user_id,
+                    reason = "session_expired",
+                    "🔗 link refused — target user not found (session may have ended)",
+                );
+                return Ok(OidcCallbackResult::LinkRefused {
+                    reason: "session_expired",
+                });
+            }
+        };
+
+        // 2. IdP must provide an email — without it we can't verify
+        //    ownership.
+        let idp_email = match claims.email.as_ref() {
+            Some(e) => e,
+            None => {
+                tracing::info!(
+                    target: "audit",
+                    event = "federation.link_refused",
+                    user_id = %user_id,
+                    reason = "email_not_provided",
+                    "🔗 link refused — IdP did not return an email claim",
+                );
+                return Ok(OidcCallbackResult::LinkRefused {
+                    reason: "email_not_provided",
+                });
+            }
+        };
+
+        // 3. Email match under +alias normalization.
+        if normalize_email_for_link(idp_email) != normalize_email_for_link(user.email()) {
+            tracing::info!(
+                target: "audit",
+                event = "federation.link_refused",
+                user_id = %user_id,
+                reason = "email_mismatch",
+                oxicloud_email_normalized = %normalize_email_for_link(user.email()),
+                idp_email_normalized = %normalize_email_for_link(idp_email),
+                "🔗 link refused — IdP email doesn't match OxiCloud user email",
+            );
+            return Ok(OidcCallbackResult::LinkRefused {
+                reason: "email_mismatch",
+            });
+        }
+
+        // 4. Idempotent-if-same / refuse-if-different: check the current
+        //    user's link state before we touch it.
+        match (
+            user.federation_kind(),
+            user.federation_issuer(),
+            user.federation_subject(),
+        ) {
+            (None, None, None) => {
+                // Fresh — proceed to link.
+            }
+            (Some(kind), Some(iss), Some(sub))
+                if kind.as_str() == "oidc" && iss == claims.iss && sub == claims.sub =>
+            {
+                // Same identity → idempotent no-op success.
+                tracing::info!(
+                    target: "audit",
+                    event = "federation.link_completed",
+                    user_id = %user_id,
+                    reason = "idempotent_repeat",
+                    federation_issuer = %claims.iss,
+                    federation_subject = %claims.sub,
+                    "🔗 link no-op — user already linked to this same identity",
+                );
+                return Ok(OidcCallbackResult::LinkCompleted { user_id });
+            }
+            _ => {
+                tracing::info!(
+                    target: "audit",
+                    event = "federation.link_refused",
+                    user_id = %user_id,
+                    reason = "already_linked",
+                    "🔗 link refused — user already linked to a different identity; unlink first",
+                );
+                return Ok(OidcCallbackResult::LinkRefused {
+                    reason: "already_linked",
+                });
+            }
+        }
+
+        // 5. Identity not already linked to a DIFFERENT user. The
+        //    UNIQUE(kind, issuer, subject) index would catch this at
+        //    UPDATE time via link_federation_identity's AlreadyExists
+        //    error, but we pre-check to emit a clean audit line and
+        //    avoid the "AlreadyExists on user" confusion in the
+        //    downstream error mapping.
+        if let Ok(other) = self
+            .user_storage
+            .get_user_by_federation_subject(&claims.iss, &claims.sub)
+            .await
+            && other.id() != user_id
+        {
+            tracing::info!(
+                target: "audit",
+                event = "federation.link_refused",
+                user_id = %user_id,
+                other_user_id = %other.id(),
+                reason = "already_linked_elsewhere",
+                "🔗 link refused — this OIDC identity is already linked to a different OxiCloud user",
+            );
+            return Ok(OidcCallbackResult::LinkRefused {
+                reason: "already_linked_elsewhere",
+            });
+        }
+
+        // All checks passed — commit the link.
+        self.user_storage
+            .link_federation_identity(user_id, "oidc", &claims.iss, &claims.sub)
+            .await?;
+
+        tracing::info!(
+            target: "audit",
+            event = "federation.link_completed",
+            user_id = %user_id,
+            federation_kind = "oidc",
+            federation_issuer = %claims.iss,
+            federation_subject = %claims.sub,
+            "🔗 self-service OIDC link completed",
+        );
+
+        Ok(OidcCallbackResult::LinkCompleted { user_id })
+    }
+
+    pub async fn unlink_oidc(&self, user_id: Uuid) -> Result<(), DomainError> {
+        let user = self.user_storage.get_user_by_id(user_id).await?;
+
+        // Idempotent: unlinking an already-unlinked user is a success.
+        if user.federation_kind().is_none() {
+            tracing::info!(
+                target: "audit",
+                event = "federation.unlinked",
+                user_id = %user_id,
+                already_unlinked = true,
+                "🔗 unlink no-op — user was not linked"
+            );
+            return Ok(());
+        }
+
+        // The guard. `has_password` reads password_hash.is_some();
+        // `opaque_registered` needs a separate lookup because the User
+        // entity doesn't carry that flag today. We do that as a
+        // targeted query rather than dragging the full opaque_envelope
+        // column across the wire.
+        let opaque_registered = self.user_storage.is_opaque_registered(user_id).await?;
+        if !user.has_password() && !opaque_registered {
+            tracing::info!(
+                target: "audit",
+                event = "federation.unlink_refused",
+                user_id = %user_id,
+                reason = "no_alternative_auth",
+                "👮🏻‍♂️ unlink refused — user has no password/OPAQUE fallback"
+            );
+            return Err(DomainError::new(
+                ErrorKind::AccessDenied,
+                "Federation",
+                "Cannot unlink — set a password first, or you will be locked out.",
+            ));
+        }
+
+        self.user_storage
+            .unlink_federation_identity(user_id)
+            .await?;
+
+        tracing::info!(
+            target: "audit",
+            event = "federation.unlinked",
+            user_id = %user_id,
+            "🔗 OIDC identity unlinked"
+        );
+        Ok(())
     }
 
     /// Prepare an OIDC authorization flow for a Nextcloud Login Flow v2 session.
@@ -3213,6 +3537,7 @@ impl AuthApplicationService {
                 pkce_verifier,
                 nonce: nonce.clone(),
                 nc_flow_token: Some(nc_flow_token.to_string()),
+                intent: FlowIntent::Login,
             },
         );
 
@@ -3268,8 +3593,12 @@ impl AuthApplicationService {
                 ));
             }
         };
-        let (pkce_verifier, nonce, nc_flow_token) =
-            (flow.pkce_verifier, flow.nonce, flow.nc_flow_token);
+        let (pkce_verifier, nonce, nc_flow_token, intent) = (
+            flow.pkce_verifier,
+            flow.nonce,
+            flow.nc_flow_token,
+            flow.intent,
+        );
 
         // Clone the Arc and config out of the RwLock so we don't hold the lock across await points
         let (oidc, oidc_config) = {
@@ -3328,6 +3657,20 @@ impl AuthApplicationService {
         } else {
             claims
         };
+
+        // ────────────────────────────────────────────────────────────
+        // Flow-intent dispatch — if this callback was initiated by
+        // the self-service link path (`POST /api/auth/oidc/link/start`),
+        // divert here BEFORE the login-specific processing (email
+        // verification gate / JIT / session mint). Login stays on the
+        // fall-through path. See docs/plan/oidc-account-linking.md.
+        // ────────────────────────────────────────────────────────────
+        if let FlowIntent::Link {
+            user_id: target_user_id,
+        } = intent
+        {
+            return self.complete_oidc_link(target_user_id, &claims).await;
+        }
 
         let provider_name = oidc.provider_name().to_string();
         // Email-verification gate. The operator flag
@@ -3492,144 +3835,216 @@ impl AuthApplicationService {
                 existing_user
             }
             Err(_) => {
-                // User doesn't exist — try to match by email
+                // User doesn't exist by federation subject — try to
+                // match by email. Two possible outcomes:
+                //   * Email matches an existing local user AND the
+                //     auto-link decision tree accepts → auto-link,
+                //     yield the linked user (falls through to session
+                //     mint below).
+                //   * Email matches AND auto-link refuses (config off,
+                //     email not verified, already linked elsewhere) →
+                //     return "contact admin" error (self-service link
+                //     flow remains available).
+                //   * No email match → JIT provision (existing branch).
+                //
+                // NOTE (MVP scope): exact-match lookup only. If OxiCloud
+                // stores `alice+work@example.com` but the IdP returns
+                // `alice@example.com`, the exact match misses even
+                // though they normalise to the same value. The user
+                // falls through to the "contact admin" refusal and can
+                // self-serve via the profile link flow.
                 let matched_user = self.user_storage.get_user_by_email(&oidc_email).await.ok();
 
-                if let Some(_existing) = matched_user {
-                    // Email match but no OIDC link — for security, don't auto-link
-                    return Err(DomainError::new(
-                        ErrorKind::AlreadyExists,
-                        "OIDC",
-                        format!(
-                            "A user with email '{}' already exists. Contact admin to link your OIDC identity.",
-                            oidc_email
-                        ),
-                    ));
-                }
+                if let Some(matched) = matched_user {
+                    // Auto-link decision tree — see
+                    // docs/plan/oidc-account-linking.md § Auto-link.
+                    let can_auto_link = oidc_config.auto_link_email_match
+                        && claims.email_verified == Some(true)
+                        && matched.federation_kind().is_none();
 
-                // No match — JIT provision if enabled
-                if !oidc_config.auto_provision {
-                    return Err(DomainError::new(
-                        ErrorKind::AccessDenied,
-                        "OIDC",
-                        "Auto-provisioning is disabled. Contact admin to create your account.",
-                    ));
-                }
+                    if !can_auto_link {
+                        let reason = if !oidc_config.auto_link_email_match {
+                            "auto_link_disabled"
+                        } else if claims.email_verified != Some(true) {
+                            "auto_link_email_not_verified"
+                        } else {
+                            "already_linked_elsewhere"
+                        };
+                        tracing::info!(
+                            target: "audit",
+                            event = "federation.auto_link_refused",
+                            user_id = %matched.id(),
+                            reason = reason,
+                            "🔗 auto-link refused",
+                        );
+                        return Err(DomainError::new(
+                            ErrorKind::AlreadyExists,
+                            "OIDC",
+                            format!(
+                                "A user with email '{}' already exists. Contact admin to link your OIDC identity.",
+                                oidc_email
+                            ),
+                        ));
+                    }
 
-                // Determine role from OIDC groups
-                let role = self.map_oidc_role(&claims.groups, &oidc_config);
-
-                let quota = self.capped_quota(&role);
-
-                // Sanitize username: if it looks like an email, extract the local part
-                // (some OIDC providers like Keycloak use email as the preferred username)
-                let base_username = if oidc_username.contains('@') {
-                    oidc_username.split('@').next().unwrap_or(&oidc_username)
+                    // All checks passed — commit the auto-link, re-fetch
+                    // to observe the fresh federation columns, then run
+                    // the same login-side effects as the "existing user"
+                    // arm above (lifecycle dispatch, register_login,
+                    // avatar/verification sync).
+                    self.user_storage
+                        .link_federation_identity(matched.id(), "oidc", &claims.iss, &claims.sub)
+                        .await?;
+                    tracing::info!(
+                        target: "audit",
+                        event = "federation.auto_linked",
+                        reason = "email_match_verified",
+                        user_id = %matched.id(),
+                        federation_kind = "oidc",
+                        federation_issuer = %claims.iss,
+                        federation_subject = %claims.sub,
+                        "🔗 OIDC identity auto-linked to existing local user via verified email match",
+                    );
+                    let mut linked_user = self.user_storage.get_user_by_id(matched.id()).await?;
+                    if let Some(lc) = &self.user_lifecycle {
+                        lc.dispatch_login(&linked_user).await;
+                    }
+                    linked_user.register_login();
+                    linked_user.set_image(claims.picture.clone());
+                    linked_user.mark_email_verified();
+                    self.user_storage
+                        .sync_oidc_login_profile(linked_user.id(), claims.picture.as_deref())
+                        .await?;
+                    // Yield the linked user — same shape as the
+                    // Ok(existing_user) arm's tail expression.
+                    linked_user
                 } else {
-                    &oidc_username
-                };
+                    // No email match — JIT provision (existing behavior).
+                    if !oidc_config.auto_provision {
+                        return Err(DomainError::new(
+                            ErrorKind::AccessDenied,
+                            "OIDC",
+                            "Auto-provisioning is disabled. Contact admin to create your account.",
+                        ));
+                    }
 
-                // Filter to valid username characters only, then truncate to 32 chars
-                let mut username = base_username
-                    .chars()
-                    .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_' || *c == '.')
-                    .take(32)
-                    .collect::<String>();
+                    // Determine role from OIDC groups
+                    let role = self.map_oidc_role(&claims.groups, &oidc_config);
 
-                // Filter helper: removes any chars that are not valid in a username
-                let filter_username_chars = |s: &str| {
-                    s.chars()
+                    let quota = self.capped_quota(&role);
+
+                    // Sanitize username: if it looks like an email, extract the local part
+                    // (some OIDC providers like Keycloak use email as the preferred username)
+                    let base_username = if oidc_username.contains('@') {
+                        oidc_username.split('@').next().unwrap_or(&oidc_username)
+                    } else {
+                        &oidc_username
+                    };
+
+                    // Filter to valid username characters only, then truncate to 32 chars
+                    let mut username = base_username
+                        .chars()
                         .filter(|c| {
                             c.is_ascii_alphanumeric() || *c == '-' || *c == '_' || *c == '.'
                         })
                         .take(32)
-                        .collect::<String>()
-                };
+                        .collect::<String>();
 
-                // Ensure minimum length (the padding suffix must also be filtered)
-                if username.len() < 3 {
-                    let filtered_sub = filter_username_chars(&claims.sub);
-                    username = format!("user_{}", &filtered_sub[..filtered_sub.len().min(8)]);
-                }
+                    // Filter helper: removes any chars that are not valid in a username
+                    let filter_username_chars = |s: &str| {
+                        s.chars()
+                            .filter(|c| {
+                                c.is_ascii_alphanumeric() || *c == '-' || *c == '_' || *c == '.'
+                            })
+                            .take(32)
+                            .collect::<String>()
+                    };
 
-                // Check for username collision
-                if self
-                    .user_storage
-                    .get_user_by_username(&username)
-                    .await
-                    .is_ok()
-                {
-                    let filtered_sub = filter_username_chars(&claims.sub);
-                    let suffix = &filtered_sub[..filtered_sub.len().min(4)];
-                    username = format!("{}_{}", &username[..username.len().min(27)], suffix);
-                }
+                    // Ensure minimum length (the padding suffix must also be filtered)
+                    if username.len() < 3 {
+                        let filtered_sub = filter_username_chars(&claims.sub);
+                        username = format!("user_{}", &filtered_sub[..filtered_sub.len().min(8)]);
+                    }
 
-                let mut new_user = User::new(
-                    oidc_email,
-                    Some(username.clone()),
-                    None,
-                    Some(crate::domain::entities::user::FederationKind::Oidc),
-                    // Phase B canonical value: the id_token's real `iss`
-                    // claim (validated to equal discovery.issuer in
-                    // OidcService). No more display-label writes at JIT —
-                    // legacy rows are fixed via lazy rebind in the
-                    // existing-user branch above.
-                    Some(claims.iss.clone()),
-                    Some(claims.sub.clone()),
-                    role,
-                    quota,
-                    false,
-                )
-                .map_err(|e| {
-                    DomainError::new(
-                        ErrorKind::InvalidInput,
-                        "OIDC",
-                        format!("Failed to create OIDC user: {}", e),
+                    // Check for username collision
+                    if self
+                        .user_storage
+                        .get_user_by_username(&username)
+                        .await
+                        .is_ok()
+                    {
+                        let filtered_sub = filter_username_chars(&claims.sub);
+                        let suffix = &filtered_sub[..filtered_sub.len().min(4)];
+                        username = format!("{}_{}", &username[..username.len().min(27)], suffix);
+                    }
+
+                    let mut new_user = User::new(
+                        oidc_email,
+                        Some(username.clone()),
+                        None,
+                        Some(crate::domain::entities::user::FederationKind::Oidc),
+                        // Phase B canonical value: the id_token's real `iss`
+                        // claim (validated to equal discovery.issuer in
+                        // OidcService). No more display-label writes at JIT —
+                        // legacy rows are fixed via lazy rebind in the
+                        // existing-user branch above.
+                        Some(claims.iss.clone()),
+                        Some(claims.sub.clone()),
+                        role,
+                        quota,
+                        false,
                     )
-                })?;
-                new_user.set_image(claims.picture.clone());
-                new_user.set_given_name(claims.given_name.clone());
-                new_user.set_family_name(claims.family_name.clone());
-                // PR C: provision the user's preferred_locale from the
-                // OIDC `locale` claim AT JIT ONLY. Subsequent logins
-                // never re-apply this — a UI-driven choice ("I prefer
-                // English even though my IdP says fr-CA") must not be
-                // silently overwritten on the next sign-in. We validate
-                // the claim against the registry so an obscure or
-                // malformed code (e.g. `klingon`, `fr-FR-x-private`)
-                // doesn't end up stored only to fail at render time;
-                // unresolvable claims fall through to NULL → server
-                // default.
-                if let Some(claim) = claims.locale.as_deref()
-                    && let Some(canonical) = locale_registry.parse(claim)
-                {
-                    new_user.set_preferred_locale(Some(canonical.as_str().to_string()));
+                    .map_err(|e| {
+                        DomainError::new(
+                            ErrorKind::InvalidInput,
+                            "OIDC",
+                            format!("Failed to create OIDC user: {}", e),
+                        )
+                    })?;
+                    new_user.set_image(claims.picture.clone());
+                    new_user.set_given_name(claims.given_name.clone());
+                    new_user.set_family_name(claims.family_name.clone());
+                    // PR C: provision the user's preferred_locale from the
+                    // OIDC `locale` claim AT JIT ONLY. Subsequent logins
+                    // never re-apply this — a UI-driven choice ("I prefer
+                    // English even though my IdP says fr-CA") must not be
+                    // silently overwritten on the next sign-in. We validate
+                    // the claim against the registry so an obscure or
+                    // malformed code (e.g. `klingon`, `fr-FR-x-private`)
+                    // doesn't end up stored only to fail at render time;
+                    // unresolvable claims fall through to NULL → server
+                    // default.
+                    if let Some(claim) = claims.locale.as_deref()
+                        && let Some(canonical) = locale_registry.parse(claim)
+                    {
+                        new_user.set_preferred_locale(Some(canonical.as_str().to_string()));
+                    }
+                    // PR 23: the OIDC callback rejected any caller upstream
+                    // whose `email_verified` claim wasn't true, so users
+                    // reaching this branch have an IdP-vetted email. Stamp
+                    // the verification at JIT-create time.
+                    new_user.mark_email_verified();
+
+                    let created_user = self.user_storage.create_user(new_user).await?;
+
+                    // Lifecycle: created (audit + home-folder provisioning) +
+                    // login (no register_login() for a fresh OIDC user means
+                    // `last_login_at` is naturally None → first-login detection
+                    // works). PersonalDriveLifecycleHook creates the home folder.
+                    if let Some(lc) = &self.user_lifecycle {
+                        lc.dispatch_created(&created_user).await;
+                        lc.dispatch_login(&created_user).await;
+                    }
+
+                    tracing::info!(
+                        "OIDC user provisioned: {} (provider: {}, sub: {})",
+                        created_user.id(),
+                        provider_name,
+                        claims.sub
+                    );
+
+                    created_user
                 }
-                // PR 23: the OIDC callback rejected any caller upstream
-                // whose `email_verified` claim wasn't true, so users
-                // reaching this branch have an IdP-vetted email. Stamp
-                // the verification at JIT-create time.
-                new_user.mark_email_verified();
-
-                let created_user = self.user_storage.create_user(new_user).await?;
-
-                // Lifecycle: created (audit + home-folder provisioning) +
-                // login (no register_login() for a fresh OIDC user means
-                // `last_login_at` is naturally None → first-login detection
-                // works). PersonalDriveLifecycleHook creates the home folder.
-                if let Some(lc) = &self.user_lifecycle {
-                    lc.dispatch_created(&created_user).await;
-                    lc.dispatch_login(&created_user).await;
-                }
-
-                tracing::info!(
-                    "OIDC user provisioned: {} (provider: {}, sub: {})",
-                    created_user.id(),
-                    provider_name,
-                    claims.sub
-                );
-
-                created_user
             }
         };
 

--- a/src/application/services/magic_link_invite_service.rs
+++ b/src/application/services/magic_link_invite_service.rs
@@ -225,12 +225,18 @@ impl MagicLinkInviteService {
 
         // External users are created without a username or password.
         // `password_hash IS NULL` is the canonical no-password marker.
+        //
+        // federation_kind stays None in Phase A of the federation-identity
+        // rename — magic-link externals get their `federation_kind` stamp
+        // in a future PR when the invite handler is refactored to opt into
+        // the composable federation model. Behaviour is unchanged today.
         let mut user = User::new(
             normalised_email.to_string(),
             None,
             None,
-            None,
-            None,
+            None, // federation_kind
+            None, // federation_issuer
+            None, // federation_subject
             UserRole::User,
             0,
             true,
@@ -1006,15 +1012,21 @@ mod tests {
     use crate::domain::entities::user::{User, UserRole};
 
     fn user(password: Option<&str>, oidc: Option<(&str, &str)>) -> User {
-        let (provider, subject) = match oidc {
-            Some((p, s)) => (Some(p.to_string()), Some(s.to_string())),
-            None => (None, None),
+        use crate::domain::entities::user::FederationKind;
+        let (kind, issuer, subject) = match oidc {
+            Some((p, s)) => (
+                Some(FederationKind::Oidc),
+                Some(p.to_string()),
+                Some(s.to_string()),
+            ),
+            None => (None, None, None),
         };
         User::new(
             "test@example.com".to_string(),
             None,
             password.map(str::to_string),
-            provider,
+            kind,
+            issuer,
             subject,
             UserRole::User,
             0,

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -1628,6 +1628,15 @@ pub struct OidcConfig {
     pub disable_password_login: bool,
     /// OIDC provider display name (shown in UI)
     pub provider_name: String,
+    /// When TRUE (default), an OIDC login whose subject doesn't match
+    /// any existing user AUTO-LINKS to the local user with the same
+    /// verified email address (if any). Requires `email_verified=true`
+    /// from the IdP. See docs/plan/oidc-account-linking.md § Auto-link.
+    ///
+    /// Set FALSE for compliance postures that require explicit consent
+    /// for every OIDC linkage. Self-service link flow still works
+    /// regardless of this flag.
+    pub auto_link_email_match: bool,
 }
 
 impl Default for OidcConfig {
@@ -1644,6 +1653,7 @@ impl Default for OidcConfig {
             admin_groups: String::new(),
             disable_password_login: false,
             provider_name: "SSO".to_string(),
+            auto_link_email_match: true,
         }
     }
 }
@@ -1851,6 +1861,9 @@ impl OidcConfig {
         }
         if let Ok(v) = env::var("OXICLOUD_OIDC_AUTO_PROVISION") {
             cfg.auto_provision = v.parse::<bool>().unwrap_or(true);
+        }
+        if let Ok(v) = env::var("OXICLOUD_OIDC_AUTO_LINK_EMAIL_MATCH") {
+            cfg.auto_link_email_match = v.parse::<bool>().unwrap_or(true);
         }
         if let Ok(v) = env::var("OXICLOUD_OIDC_ADMIN_GROUPS") {
             cfg.admin_groups = v;
@@ -3431,6 +3444,9 @@ impl AppConfig {
         }
         if let Ok(v) = env::var("OXICLOUD_OIDC_AUTO_PROVISION") {
             config.oidc.auto_provision = v.parse::<bool>().unwrap_or(true);
+        }
+        if let Ok(v) = env::var("OXICLOUD_OIDC_AUTO_LINK_EMAIL_MATCH") {
+            config.oidc.auto_link_email_match = v.parse::<bool>().unwrap_or(true);
         }
         if let Ok(v) = env::var("OXICLOUD_OIDC_ADMIN_GROUPS") {
             config.oidc.admin_groups = v;

--- a/src/common/text.rs
+++ b/src/common/text.rs
@@ -20,6 +20,39 @@ pub fn ascii_ci_contains(haystack: &[u8], needle: &[u8]) -> bool {
         .any(|w| w.eq_ignore_ascii_case(needle))
 }
 
+/// Normalize an email address for **linking-equivalence comparison**
+/// (NOT for storage — never modify what the user typed when persisting
+/// or displaying).
+///
+/// Rules:
+/// - Case-fold to ASCII lowercase (email addresses are treated as
+///   case-insensitive in practice per RFC 5321 §2.4).
+/// - Strip `+alias` sub-addressing from the local part:
+///   `alice+github@example.com` → `alice@example.com`. Supported by
+///   Gmail / Google Workspace, Outlook/O365 (since 2018), Fastmail
+///   (since ~2020), and most modern providers. Safe for a 1:1
+///   comparison — two same-user addresses normalise to the same value.
+///
+/// NOT doing:
+/// - Dot-stripping (Gmail-only: `a.lice@gmail.com == alice@gmail.com`).
+///   Applying universally would false-positive on providers that treat
+///   dots as significant.
+/// - Unicode normalisation — email addresses compare as ASCII already.
+///
+/// Load-bearing for `POST /api/auth/oidc/link/start` → callback and
+/// for the auto-link decision on OIDC login. See
+/// docs/plan/oidc-account-linking.md § Safety checks.
+pub fn normalize_email_for_link(email: &str) -> String {
+    let lower = email.trim().to_ascii_lowercase();
+    let Some((local, domain)) = lower.split_once('@') else {
+        // Malformed — return the lowercased form; caller's comparison
+        // will fail naturally.
+        return lower;
+    };
+    let local_base = local.split_once('+').map(|(b, _)| b).unwrap_or(local);
+    format!("{}@{}", local_base, domain)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -50,5 +83,84 @@ mod tests {
     #[test]
     fn empty_needle_is_true() {
         assert!(ascii_ci_contains(b"anything", b""));
+    }
+
+    #[test]
+    fn normalize_email_for_link_matrix() {
+        // Behaviour matrix from docs/plan/oidc-account-linking.md
+        // § Email normalization. Left = raw, right = expected normalized.
+        let cases: &[(&str, &str)] = &[
+            // Identity
+            ("alice@example.com", "alice@example.com"),
+            // Case fold
+            ("Alice@Example.COM", "alice@example.com"),
+            // +alias stripped
+            ("alice+github@example.com", "alice@example.com"),
+            ("alice+oidc@example.com", "alice@example.com"),
+            // Both sides of a match normalise the same way
+            ("alice+work@example.com", "alice@example.com"),
+            // Empty +alias suffix is still stripped
+            ("alice+@example.com", "alice@example.com"),
+            // Multiple + in local: everything after the FIRST + is dropped
+            ("alice+work+extra@example.com", "alice@example.com"),
+            // Trim leading/trailing whitespace
+            ("  alice@example.com  ", "alice@example.com"),
+            // Different local parts stay different
+            ("bob@example.com", "bob@example.com"),
+            // Different domains stay different (no cross-domain equivalence)
+            ("alice@corp.com", "alice@corp.com"),
+            // Domain case-folded too
+            ("alice@Example.COM", "alice@example.com"),
+        ];
+        for (raw, expected) in cases {
+            assert_eq!(
+                normalize_email_for_link(raw),
+                *expected,
+                "normalize_email_for_link({raw:?}) should equal {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_email_link_equivalence_pairs() {
+        // Anti-drift: pairs that MUST compare equal after normalization
+        // (the "auto-link email match" cases the plan doc lists as ✅).
+        let equivalent: &[(&str, &str)] = &[
+            ("alice@example.com", "alice@example.com"),
+            ("alice@example.com", "Alice@example.com"),
+            ("alice@example.com", "alice+oidc@example.com"),
+            ("alice+work@example.com", "alice@example.com"),
+            ("alice+work@example.com", "alice+home@example.com"),
+        ];
+        for (left, right) in equivalent {
+            assert_eq!(
+                normalize_email_for_link(left),
+                normalize_email_for_link(right),
+                "{left:?} should equal {right:?} under linking normalization"
+            );
+        }
+
+        // Pairs that MUST NOT match — the plan's ❌ cases.
+        let distinct: &[(&str, &str)] = &[
+            ("alice@example.com", "bob@example.com"),
+            ("alice@example.com", "alice@corp.com"),
+            // Dot-stripping deliberately NOT applied — dots stay significant.
+            ("a.lice@gmail.com", "alice@gmail.com"),
+        ];
+        for (left, right) in distinct {
+            assert_ne!(
+                normalize_email_for_link(left),
+                normalize_email_for_link(right),
+                "{left:?} MUST NOT equal {right:?} — dot-stripping is Gmail-only, we don't apply it"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_email_malformed_returns_lowercased() {
+        // No `@` → return lowercased trimmed form; the caller's
+        // downstream comparison will fail naturally.
+        assert_eq!(normalize_email_for_link("not-an-email"), "not-an-email");
+        assert_eq!(normalize_email_for_link("  MIXED-Case  "), "mixed-case");
     }
 }

--- a/src/domain/entities/user.rs
+++ b/src/domain/entities/user.rs
@@ -355,7 +355,8 @@ impl User {
         // only fires on inconsistent partial state.
         if federation_issuer.is_some() != federation_subject.is_some() {
             return Err(UserError::ValidationError(
-                "federation_issuer and federation_subject must both be set or both be None".to_string(),
+                "federation_issuer and federation_subject must both be set or both be None"
+                    .to_string(),
             ));
         }
         // If either field is set, federation_kind MUST also be set — the

--- a/src/domain/entities/user.rs
+++ b/src/domain/entities/user.rs
@@ -28,6 +28,62 @@ impl std::fmt::Display for UserRole {
     }
 }
 
+/// The trust chain that owns a user's identity. NULL on `auth.users`
+/// means "pure local user, no external federation" — the common case for
+/// password/OPAQUE accounts.
+///
+/// See `docs/plan/ocm.md § Identity & auth model` for the full model
+/// including the `(federation_kind, federation_issuer, federation_subject)`
+/// composite identity key.
+///
+/// - `Oidc`: authenticated via an OIDC provider; `federation_issuer` =
+///   the id_token `iss` claim, `federation_subject` = the `sub` claim.
+///   Note: legacy rows may still hold the OXICLOUD_OIDC_PROVIDER_NAME
+///   display label as `federation_issuer` until Phase B of the rename
+///   backfills them to real issuer URLs.
+/// - `Ocm`: OCM 1.1 federated principal (future — `docs/plan/ocm.md`).
+///   `federation_issuer` = peer domain, `federation_subject` = federated
+///   address (e.g. `alice@remote.example.com`).
+/// - `MagicLink`: external invitee whose only auth is mailbox
+///   possession. Both `federation_issuer` and `federation_subject`
+///   remain NULL for this kind — the identity is the local `email`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FederationKind {
+    MagicLink,
+    Ocm,
+    Oidc,
+}
+
+impl FederationKind {
+    /// Canonical DB / wire spelling — matches the CHECK constraint on
+    /// `auth.users.federation_kind`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FederationKind::MagicLink => "magic_link",
+            FederationKind::Ocm => "ocm",
+            FederationKind::Oidc => "oidc",
+        }
+    }
+
+    /// Parse the DB / wire spelling. Returns `None` for anything other
+    /// than the three canonical values — the CHECK constraint on the
+    /// column and the enum variants are the source of truth.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "magic_link" => Some(FederationKind::MagicLink),
+            "ocm" => Some(FederationKind::Ocm),
+            "oidc" => Some(FederationKind::Oidc),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for FederationKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Authorization-relevant account flags, fetched without the heavyweight
 /// profile columns. The full user row drags `image` along — a data URI of
 /// up to 512 KiB — which per-request guards (`require_internal_user`,
@@ -72,8 +128,12 @@ pub struct User {
     updated_at: DateTime<Utc>,
     last_login_at: Option<DateTime<Utc>>,
     active: bool,
-    oidc_provider: Option<String>,
-    oidc_subject: Option<String>,
+    /// Which trust chain minted the (issuer, subject) pair. `None` on
+    /// pure local users (password/OPAQUE). See [`FederationKind`] for the
+    /// three federation flavours.
+    federation_kind: Option<FederationKind>,
+    federation_issuer: Option<String>,
+    federation_subject: Option<String>,
     image: Option<String>,
     /// TRUE = grant-only external recipient (magic-link, OIDC-only, OCM
     /// federated). FALSE = storage-owning internal user. Hooks that
@@ -161,8 +221,9 @@ pub struct UserParts {
     pub updated_at: DateTime<Utc>,
     pub last_login_at: Option<DateTime<Utc>>,
     pub active: bool,
-    pub oidc_provider: Option<String>,
-    pub oidc_subject: Option<String>,
+    pub federation_kind: Option<FederationKind>,
+    pub federation_issuer: Option<String>,
+    pub federation_subject: Option<String>,
     pub image: Option<String>,
     pub is_external: bool,
     pub given_name: Option<String>,
@@ -190,8 +251,9 @@ impl User {
             updated_at,
             last_login_at,
             active,
-            oidc_provider,
-            oidc_subject,
+            federation_kind,
+            federation_issuer,
+            federation_subject,
             image,
             is_external,
             given_name,
@@ -213,8 +275,9 @@ impl User {
             updated_at,
             last_login_at,
             active,
-            oidc_provider,
-            oidc_subject,
+            federation_kind,
+            federation_issuer,
+            federation_subject,
             image,
             is_external,
             given_name,
@@ -230,7 +293,7 @@ impl User {
     ///
     /// One unified constructor for every kind of user (internal, OIDC-linked,
     /// external). The credential slots and the `is_external` marker are all
-    /// caller-controlled — what makes a user "OIDC" is `oidc_subject =
+    /// caller-controlled — what makes a user "OIDC" is `federation_subject =
     /// Some(_)`, what makes them "external" is `is_external = true`. There
     /// are no hidden sentinel values; an absent credential is `None`.
     ///
@@ -239,7 +302,7 @@ impl User {
     /// * `username` — optional handle (2-64 chars, no `@`)
     /// * `password_hash` — pre-hashed via PasswordHasherPort, or `None` if
     ///   the user has no password yet (magic-link or OIDC bootstrap)
-    /// * `oidc_provider`, `oidc_subject` — both `Some` when the user is
+    /// * `federation_issuer`, `federation_subject` — both `Some` when the user is
     ///   linked to an external IdP, both `None` otherwise
     /// * `role` — `Admin` is rejected when `is_external = true` (mirrors the
     ///   `users_external_not_admin` DB CHECK constraint)
@@ -251,8 +314,9 @@ impl User {
         email: String,
         username: Option<String>,
         password_hash: Option<String>,
-        oidc_provider: Option<String>,
-        oidc_subject: Option<String>,
+        federation_kind: Option<FederationKind>,
+        federation_issuer: Option<String>,
+        federation_subject: Option<String>,
         role: UserRole,
         storage_quota_bytes: i64,
         is_external: bool,
@@ -280,12 +344,26 @@ impl User {
                 "External users must have storage_quota_bytes = 0".to_string(),
             ));
         }
-        // OIDC linkage is all-or-nothing: both provider and subject set,
-        // or neither. The DB has a UNIQUE index on (provider, subject)
-        // WHERE both non-NULL; partial state would corrupt that.
-        if oidc_provider.is_some() != oidc_subject.is_some() {
+        // Federation linkage is all-or-nothing: both issuer and subject set,
+        // or neither. The DB has a UNIQUE index on
+        // (federation_kind, federation_issuer, federation_subject) WHERE
+        // federation_kind IS NOT NULL; partial state would corrupt that.
+        //
+        // For kinds that don't carry an authority-issued subject
+        // (MagicLink today — identity is the local email), both fields
+        // stay None even when `federation_kind` is set. The check below
+        // only fires on inconsistent partial state.
+        if federation_issuer.is_some() != federation_subject.is_some() {
             return Err(UserError::ValidationError(
-                "oidc_provider and oidc_subject must both be set or both be None".to_string(),
+                "federation_issuer and federation_subject must both be set or both be None".to_string(),
+            ));
+        }
+        // If either field is set, federation_kind MUST also be set — the
+        // schema keys anti-duplicate on the composite (kind, issuer,
+        // subject) and a NULL kind would defeat the uniqueness.
+        if federation_issuer.is_some() && federation_kind.is_none() {
+            return Err(UserError::ValidationError(
+                "federation_kind is required when federation_issuer/subject are set".to_string(),
             ));
         }
 
@@ -302,8 +380,9 @@ impl User {
             updated_at: now,
             last_login_at: None,
             active: true,
-            oidc_provider,
-            oidc_subject,
+            federation_kind,
+            federation_issuer,
+            federation_subject,
             image: None,
             is_external,
             given_name: None,
@@ -355,8 +434,9 @@ impl User {
             updated_at,
             last_login_at,
             active,
-            oidc_provider: None,
-            oidc_subject: None,
+            federation_kind: None,
+            federation_issuer: None,
+            federation_subject: None,
             image: None,
             // `from_data` is the minimal-args reconstruction path used by
             // tests and JWT-claim-based principal hydration (which doesn't
@@ -387,8 +467,9 @@ impl User {
         updated_at: DateTime<Utc>,
         last_login_at: Option<DateTime<Utc>>,
         active: bool,
-        oidc_provider: Option<String>,
-        oidc_subject: Option<String>,
+        federation_kind: Option<FederationKind>,
+        federation_issuer: Option<String>,
+        federation_subject: Option<String>,
         image: Option<String>,
         is_external: bool,
         given_name: Option<String>,
@@ -413,8 +494,9 @@ impl User {
             updated_at,
             last_login_at,
             active,
-            oidc_provider,
-            oidc_subject,
+            federation_kind,
+            federation_issuer,
+            federation_subject,
             image,
             is_external,
             given_name,
@@ -556,12 +638,16 @@ impl User {
         format!("{}…", &self.id.to_string()[..8])
     }
 
-    pub fn oidc_provider(&self) -> Option<&str> {
-        self.oidc_provider.as_deref()
+    pub fn federation_kind(&self) -> Option<FederationKind> {
+        self.federation_kind
     }
 
-    pub fn oidc_subject(&self) -> Option<&str> {
-        self.oidc_subject.as_deref()
+    pub fn federation_issuer(&self) -> Option<&str> {
+        self.federation_issuer.as_deref()
+    }
+
+    pub fn federation_subject(&self) -> Option<&str> {
+        self.federation_subject.as_deref()
     }
 
     pub fn image(&self) -> Option<&str> {
@@ -739,7 +825,7 @@ impl User {
 
     /// Returns true if this is an OIDC-only user (no password)
     pub fn is_oidc_user(&self) -> bool {
-        self.oidc_provider.is_some()
+        self.federation_issuer.is_some()
     }
 
     /// Returns true iff this user has any non-magic-link authentication
@@ -748,7 +834,7 @@ impl User {
     /// the negation of this; the `OXICLOUD_MAGIC_LINK_OPEN_TO_PASSWORD_USERS`
     /// flag widens the policy at the service layer (`magic_link_eligibility`).
     pub fn has_login_credential(&self) -> bool {
-        self.password_hash.is_some() || self.oidc_subject.is_some()
+        self.password_hash.is_some() || self.federation_subject.is_some()
     }
 
     /// Set the password hash. The new password must be hashed externally
@@ -891,9 +977,10 @@ mod tests {
             Utc::now(),
             None,
             true,
-            None,
-            None,
-            None,
+            None, // federation_kind
+            None, // federation_issuer
+            None, // federation_subject
+            None, // image
             false,
             given.map(str::to_string),
             family.map(str::to_string),

--- a/src/domain/repositories/session_repository.rs
+++ b/src/domain/repositories/session_repository.rs
@@ -81,16 +81,16 @@ pub trait SessionRepository: Send + Sync + 'static {
     async fn revoke_sessions_by_oidc_sid(&self, sid: &str) -> SessionRepositoryResult<Vec<Uuid>>;
 
     /// Revokes every session belonging to the user identified by
-    /// `(oidc_provider, oidc_subject)`.
+    /// `(federation_issuer, federation_subject)`.
     ///
     /// Fallback path for the Back-Channel Logout handler when the IdP
     /// omits `sid` from the logout_token — coarser than sid-based
     /// revocation (kills the user's other devices too). Returns the
     /// user id of the affected account, or `None` if no matching user.
-    async fn revoke_user_sessions_by_oidc_subject(
+    async fn revoke_user_sessions_by_federation_subject(
         &self,
-        oidc_provider: &str,
-        oidc_subject: &str,
+        issuer: &str,
+        subject: &str,
     ) -> SessionRepositoryResult<Option<Uuid>>;
 
     /// Deletes expired sessions

--- a/src/domain/repositories/user_repository.rs
+++ b/src/domain/repositories/user_repository.rs
@@ -107,6 +107,24 @@ pub trait UserRepository: Send + Sync + 'static {
     /// Gets a user by email
     async fn get_user_by_email(&self, email: &str) -> UserRepositoryResult<User>;
 
+    /// Returns every user whose email normalizes to `normalized_email`.
+    ///
+    /// Normalization matches `common::text::normalize_email_for_link` —
+    /// lowercase + strip `+alias` sub-addressing — so
+    /// `Alice+work@Example.com` and `alice@example.com` collapse to the
+    /// same key. Used by the OIDC auto-link decision tree to detect
+    /// ambiguity: two local rows normalizing to the IdP-returned email
+    /// means we can't safely pick one to auto-link, and the callback
+    /// must refuse (`email_ambiguous`).
+    ///
+    /// Caller passes the already-normalized value; the SQL applies the
+    /// same normalization to the stored side symmetrically so casing
+    /// and `+alias` differences on either side collapse.
+    async fn list_users_by_normalized_email(
+        &self,
+        normalized_email: &str,
+    ) -> UserRepositoryResult<Vec<User>>;
+
     /// Updates an existing user
     async fn update_user(&self, user: User) -> UserRepositoryResult<User>;
 

--- a/src/domain/repositories/user_repository.rs
+++ b/src/domain/repositories/user_repository.rs
@@ -45,7 +45,7 @@ pub struct UserListEntry {
     pub storage_used_bytes: i64,
     pub last_login_at: Option<DateTime<Utc>>,
     pub active: bool,
-    pub oidc_provider: Option<String>,
+    pub federation_issuer: Option<String>,
     pub is_external: bool,
     /// TRUE when `auth.users.password_hash IS NOT NULL` — user has a
     /// server-verifiable password on file (legacy or admin-set).
@@ -53,7 +53,7 @@ pub struct UserListEntry {
     /// envelope): a fully-migrated user carries BOTH — password for
     /// the fallback / operator flows, envelope for the actual login.
     /// A user with `has_password = false AND !opaque_registered AND
-    /// oidc_provider IS NULL` is passwordless — the only path in is
+    /// federation_issuer IS NULL` is passwordless — the only path in is
     /// via magic-link (or, for externals, whatever grant they hold).
     pub has_password: bool,
     /// TRUE when `auth.users.opaque_envelope IS NOT NULL` — the user
@@ -173,10 +173,10 @@ pub trait UserRepository: Send + Sync + 'static {
     /// Deletes a user
     async fn delete_user(&self, user_id: Uuid) -> UserRepositoryResult<()>;
 
-    /// Finds a user by OIDC provider + subject pair
-    async fn get_user_by_oidc_subject(
+    /// Finds a user by federation (issuer, subject) pair.
+    async fn get_user_by_federation_subject(
         &self,
-        provider: &str,
+        issuer: &str,
         subject: &str,
     ) -> UserRepositoryResult<User>;
 

--- a/src/domain/repositories/user_repository.rs
+++ b/src/domain/repositories/user_repository.rs
@@ -45,6 +45,7 @@ pub struct UserListEntry {
     pub storage_used_bytes: i64,
     pub last_login_at: Option<DateTime<Utc>>,
     pub active: bool,
+    pub federation_kind: Option<String>,
     pub federation_issuer: Option<String>,
     pub is_external: bool,
     /// TRUE when `auth.users.password_hash IS NOT NULL` — user has a

--- a/src/infrastructure/repositories/pg/session_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/session_pg_repository.rs
@@ -390,12 +390,17 @@ impl SessionRepository for SessionPgRepository {
 
     /// Back-Channel Logout fallback — the IdP omitted `sid` in the
     /// logout_token, so we revoke every session belonging to the user
-    /// identified by (oidc_provider, oidc_subject). Users are looked up
-    /// through the existing auth.users columns.
-    async fn revoke_user_sessions_by_oidc_subject(
+    /// identified by (federation_issuer, federation_subject). Users are
+    /// looked up through auth.users; the query is federation-kind-agnostic
+    /// today (matches any user regardless of federation_kind) — an OCM
+    /// notification arriving here would find only OIDC users because that's
+    /// the only path that writes federation_issuer today, but the schema
+    /// admits OCM rows too, so this method may see multi-kind matches once
+    /// OCM lands. Restrict by federation_kind then if that becomes ambiguous.
+    async fn revoke_user_sessions_by_federation_subject(
         &self,
-        oidc_provider: &str,
-        oidc_subject: &str,
+        issuer: &str,
+        subject: &str,
     ) -> SessionRepositoryResult<Option<Uuid>> {
         // Two-step: look up the user first (deterministic error class if
         // the user is unknown), then revoke. Combining into a single
@@ -404,11 +409,11 @@ impl SessionRepository for SessionPgRepository {
         let user_row = sqlx::query(
             r#"
             SELECT id FROM auth.users
-            WHERE oidc_provider = $1 AND oidc_subject = $2
+            WHERE federation_issuer = $1 AND federation_subject = $2
             "#,
         )
-        .bind(oidc_provider)
-        .bind(oidc_subject)
+        .bind(issuer)
+        .bind(subject)
         .fetch_optional(&*self.pool)
         .await
         .map_err(Self::map_sqlx_error)?;
@@ -432,9 +437,9 @@ impl SessionRepository for SessionPgRepository {
 
         tracing::info!(
             target: "audit",
-            event = "oidc.backchannel_logout_by_sub",
-            oidc_provider = %oidc_provider,
-            oidc_subject = %oidc_subject,
+            event = "federation.backchannel_logout_by_sub",
+            federation_issuer = %issuer,
+            federation_subject = %subject,
             user_id = %user_id,
             revoked_count = result.rows_affected(),
             "👮🏻‍♂️ OIDC backchannel-logout revoked all user sessions by sub"
@@ -586,12 +591,12 @@ impl SessionStoragePort for SessionPgRepository {
             .map_err(DomainError::from)
     }
 
-    async fn revoke_user_sessions_by_oidc_subject(
+    async fn revoke_user_sessions_by_federation_subject(
         &self,
-        oidc_provider: &str,
-        oidc_subject: &str,
+        issuer: &str,
+        subject: &str,
     ) -> Result<Option<Uuid>, DomainError> {
-        SessionRepository::revoke_user_sessions_by_oidc_subject(self, oidc_provider, oidc_subject)
+        SessionRepository::revoke_user_sessions_by_federation_subject(self, issuer, subject)
             .await
             .map_err(DomainError::from)
     }

--- a/src/infrastructure/repositories/pg/user_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/user_pg_repository.rs
@@ -783,6 +783,7 @@ impl UserRepository for UserPgRepository {
                 Option<chrono::DateTime<chrono::Utc>>,
                 bool,
                 Option<String>,
+                Option<String>,
                 bool,
                 bool,
                 bool,
@@ -797,13 +798,15 @@ impl UserRepository for UserPgRepository {
             // pays. `has_password` on the password_hash column tells
             // the admin table whether a server-verifiable password is
             // on file; combined with the two OPAQUE flags and
-            // federation_issuer, the SPA derives the full "capability
-            // set" per user (password / OPAQUE / SSO / passwordless).
+            // federation_kind / federation_issuer, the SPA derives the
+            // full "capability set" per user (password / OPAQUE / SSO /
+            // passwordless).
             r#"
             SELECT
                 id, username, email, role::text,
                 storage_quota_bytes, storage_used_bytes,
-                last_login_at, active, federation_issuer, is_external,
+                last_login_at, active,
+                federation_kind, federation_issuer, is_external,
                 (password_hash IS NOT NULL)       AS has_password,
                 (opaque_envelope IS NOT NULL)     AS opaque_registered,
                 (opaque_migrated_at IS NOT NULL)  AS opaque_migrated
@@ -832,6 +835,7 @@ impl UserRepository for UserPgRepository {
                     storage_used_bytes,
                     last_login_at,
                     active,
+                    federation_kind,
                     federation_issuer,
                     is_external,
                     has_password,
@@ -850,6 +854,7 @@ impl UserRepository for UserPgRepository {
                     storage_used_bytes,
                     last_login_at,
                     active,
+                    federation_kind,
                     federation_issuer,
                     is_external,
                     has_password,
@@ -1362,6 +1367,34 @@ impl UserStoragePort for UserPgRepository {
         )
         .bind(user_id)
         .bind(image)
+        .execute(&*self.pool)
+        .await
+        .map_err(Self::map_sqlx_error)
+        .map_err(DomainError::from)?;
+        Ok(())
+    }
+
+    async fn rebind_federation_issuer(
+        &self,
+        user_id: Uuid,
+        new_issuer: &str,
+    ) -> Result<(), DomainError> {
+        // Same `IS DISTINCT FROM` guard as sync_oidc_login_profile: this
+        // fires on every OIDC login, so the common already-migrated case
+        // must be a zero-write no-op. Only actually flips the column
+        // when the stored value is stale (legacy display label vs the
+        // real issuer URL from the id_token's `iss` claim).
+        sqlx::query(
+            r#"
+            UPDATE auth.users
+            SET federation_issuer = $2,
+                updated_at = NOW()
+            WHERE id = $1
+              AND federation_issuer IS DISTINCT FROM $2
+            "#,
+        )
+        .bind(user_id)
+        .bind(new_issuer)
         .execute(&*self.pool)
         .await
         .map_err(Self::map_sqlx_error)

--- a/src/infrastructure/repositories/pg/user_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/user_pg_repository.rs
@@ -282,12 +282,13 @@ impl UserRepository for UserPgRepository {
                             id, username, email, password_hash, role,
                             storage_quota_bytes, storage_used_bytes,
                             created_at, updated_at, last_login_at, active,
-                            oidc_provider, oidc_subject, image, is_external,
+                            federation_kind, federation_issuer, federation_subject,
+                            image, is_external,
                             given_name, family_name, email_verified_at,
                             preferred_locale, notify_on_share, ui_preferences
                         ) VALUES (
                             $1, $2, $3, $4, $5::auth.userrole, $6, $7, $8, $9, $10, $11,
-                            $12, $13, $14, $15, $16, $17, $18, $19, $20, $21
+                            $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22
                         )
                         RETURNING *
                         "#,
@@ -303,8 +304,9 @@ impl UserRepository for UserPgRepository {
                 .bind(user_clone.updated_at())
                 .bind(user_clone.last_login_at())
                 .bind(user_clone.is_active())
-                .bind(user_clone.oidc_provider())
-                .bind(user_clone.oidc_subject())
+                .bind(user_clone.federation_kind().map(|k| k.as_str()))
+                .bind(user_clone.federation_issuer())
+                .bind(user_clone.federation_subject())
                 .bind(user_clone.image())
                 .bind(user_clone.is_external())
                 .bind(user_clone.given_name())
@@ -339,7 +341,7 @@ impl UserRepository for UserPgRepository {
                 id, username, email, password_hash, role::text as role_text,
                 storage_quota_bytes, storage_used_bytes,
                 created_at, updated_at, last_login_at, active,
-                oidc_provider, oidc_subject, image, is_external,
+                federation_kind, federation_issuer, federation_subject, image, is_external,
                 given_name, family_name, email_verified_at, preferred_locale, notify_on_share,
                 ui_preferences
             FROM auth.users
@@ -370,8 +372,11 @@ impl UserRepository for UserPgRepository {
             row.get("updated_at"),
             row.get("last_login_at"),
             row.get("active"),
-            row.get("oidc_provider"),
-            row.get("oidc_subject"),
+            row.get::<Option<String>, _>("federation_kind")
+                .as_deref()
+                .and_then(crate::domain::entities::user::FederationKind::parse),
+            row.get("federation_issuer"),
+            row.get("federation_subject"),
             row.get("image"),
             row.get("is_external"),
             row.get("given_name"),
@@ -391,7 +396,7 @@ impl UserRepository for UserPgRepository {
                 id, username, email, password_hash, role::text as role_text,
                 storage_quota_bytes, storage_used_bytes,
                 created_at, updated_at, last_login_at, active,
-                oidc_provider, oidc_subject, image, is_external,
+                federation_kind, federation_issuer, federation_subject, image, is_external,
                 given_name, family_name, email_verified_at, preferred_locale, notify_on_share,
                 ui_preferences
             FROM auth.users
@@ -422,8 +427,11 @@ impl UserRepository for UserPgRepository {
             row.get("updated_at"),
             row.get("last_login_at"),
             row.get("active"),
-            row.get("oidc_provider"),
-            row.get("oidc_subject"),
+            row.get::<Option<String>, _>("federation_kind")
+                .as_deref()
+                .and_then(crate::domain::entities::user::FederationKind::parse),
+            row.get("federation_issuer"),
+            row.get("federation_subject"),
             row.get("image"),
             row.get("is_external"),
             row.get("given_name"),
@@ -443,7 +451,7 @@ impl UserRepository for UserPgRepository {
                 id, username, email, password_hash, role::text as role_text,
                 storage_quota_bytes, storage_used_bytes,
                 created_at, updated_at, last_login_at, active,
-                oidc_provider, oidc_subject, image, is_external,
+                federation_kind, federation_issuer, federation_subject, image, is_external,
                 given_name, family_name, email_verified_at, preferred_locale, notify_on_share,
                 ui_preferences
             FROM auth.users
@@ -474,8 +482,11 @@ impl UserRepository for UserPgRepository {
             row.get("updated_at"),
             row.get("last_login_at"),
             row.get("active"),
-            row.get("oidc_provider"),
-            row.get("oidc_subject"),
+            row.get::<Option<String>, _>("federation_kind")
+                .as_deref()
+                .and_then(crate::domain::entities::user::FederationKind::parse),
+            row.get("federation_issuer"),
+            row.get("federation_subject"),
             row.get("image"),
             row.get("is_external"),
             row.get("given_name"),
@@ -512,7 +523,7 @@ impl UserRepository for UserPgRepository {
                 id, username, email, password_hash, role::text as role_text,
                 storage_quota_bytes, storage_used_bytes,
                 created_at, updated_at, last_login_at, active,
-                oidc_provider, oidc_subject, is_external,
+                federation_kind, federation_issuer, federation_subject, is_external,
                 given_name, family_name, email_verified_at, preferred_locale, notify_on_share
             FROM auth.users
             WHERE id = ANY($1)
@@ -544,8 +555,11 @@ impl UserRepository for UserPgRepository {
                     row.get("updated_at"),
                     row.get("last_login_at"),
                     row.get("active"),
-                    row.get("oidc_provider"),
-                    row.get("oidc_subject"),
+                    row.get::<Option<String>, _>("federation_kind")
+                        .as_deref()
+                        .and_then(crate::domain::entities::user::FederationKind::parse),
+                    row.get("federation_issuer"),
+                    row.get("federation_subject"),
                     None, // image — not projected (notification-recipient path)
                     row.get("is_external"),
                     row.get("given_name"),
@@ -693,7 +707,7 @@ impl UserRepository for UserPgRepository {
                 id, username, email, password_hash, role::text as role_text,
                 storage_quota_bytes, storage_used_bytes,
                 created_at, updated_at, last_login_at, active,
-                oidc_provider, oidc_subject, image, is_external,
+                federation_kind, federation_issuer, federation_subject, image, is_external,
                 given_name, family_name, email_verified_at, preferred_locale, notify_on_share,
                 ui_preferences
             FROM auth.users
@@ -731,8 +745,11 @@ impl UserRepository for UserPgRepository {
                     row.get("updated_at"),
                     row.get("last_login_at"),
                     row.get("active"),
-                    row.get("oidc_provider"),
-                    row.get("oidc_subject"),
+                    row.get::<Option<String>, _>("federation_kind")
+                        .as_deref()
+                        .and_then(crate::domain::entities::user::FederationKind::parse),
+                    row.get("federation_issuer"),
+                    row.get("federation_subject"),
                     row.get("image"),
                     row.get("is_external"),
                     row.get("given_name"),
@@ -780,13 +797,13 @@ impl UserRepository for UserPgRepository {
             // pays. `has_password` on the password_hash column tells
             // the admin table whether a server-verifiable password is
             // on file; combined with the two OPAQUE flags and
-            // oidc_provider, the SPA derives the full "capability
+            // federation_issuer, the SPA derives the full "capability
             // set" per user (password / OPAQUE / SSO / passwordless).
             r#"
             SELECT
                 id, username, email, role::text,
                 storage_quota_bytes, storage_used_bytes,
-                last_login_at, active, oidc_provider, is_external,
+                last_login_at, active, federation_issuer, is_external,
                 (password_hash IS NOT NULL)       AS has_password,
                 (opaque_envelope IS NOT NULL)     AS opaque_registered,
                 (opaque_migrated_at IS NOT NULL)  AS opaque_migrated
@@ -815,7 +832,7 @@ impl UserRepository for UserPgRepository {
                     storage_used_bytes,
                     last_login_at,
                     active,
-                    oidc_provider,
+                    federation_issuer,
                     is_external,
                     has_password,
                     opaque_registered,
@@ -833,7 +850,7 @@ impl UserRepository for UserPgRepository {
                     storage_used_bytes,
                     last_login_at,
                     active,
-                    oidc_provider,
+                    federation_issuer,
                     is_external,
                     has_password,
                     opaque_registered,
@@ -856,7 +873,7 @@ impl UserRepository for UserPgRepository {
                 id, username, email, password_hash, role::text as role_text,
                 storage_quota_bytes, storage_used_bytes,
                 created_at, updated_at, last_login_at, active,
-                oidc_provider, oidc_subject, image, is_external,
+                federation_kind, federation_issuer, federation_subject, image, is_external,
                 given_name, family_name, email_verified_at, preferred_locale, notify_on_share,
                 ui_preferences
             FROM auth.users
@@ -894,8 +911,11 @@ impl UserRepository for UserPgRepository {
                     row.get("updated_at"),
                     row.get("last_login_at"),
                     row.get("active"),
-                    row.get("oidc_provider"),
-                    row.get("oidc_subject"),
+                    row.get::<Option<String>, _>("federation_kind")
+                        .as_deref()
+                        .and_then(crate::domain::entities::user::FederationKind::parse),
+                    row.get("federation_issuer"),
+                    row.get("federation_subject"),
                     row.get("image"),
                     row.get("is_external"),
                     row.get("given_name"),
@@ -999,7 +1019,7 @@ impl UserRepository for UserPgRepository {
                 id, username, email, password_hash, role::text as role_text,
                 storage_quota_bytes, storage_used_bytes,
                 created_at, updated_at, last_login_at, active,
-                oidc_provider, oidc_subject, image, is_external,
+                federation_kind, federation_issuer, federation_subject, image, is_external,
                 given_name, family_name, email_verified_at, preferred_locale, notify_on_share,
                 ui_preferences
             FROM auth.users
@@ -1034,8 +1054,11 @@ impl UserRepository for UserPgRepository {
                     row.get("updated_at"),
                     row.get("last_login_at"),
                     row.get("active"),
-                    row.get("oidc_provider"),
-                    row.get("oidc_subject"),
+                    row.get::<Option<String>, _>("federation_kind")
+                        .as_deref()
+                        .and_then(crate::domain::entities::user::FederationKind::parse),
+                    row.get("federation_issuer"),
+                    row.get("federation_subject"),
                     row.get("image"),
                     row.get("is_external"),
                     row.get("given_name"),
@@ -1068,7 +1091,7 @@ impl UserRepository for UserPgRepository {
     }
 
     /// Finds a user by OIDC provider + subject pair
-    async fn get_user_by_oidc_subject(
+    async fn get_user_by_federation_subject(
         &self,
         provider: &str,
         subject: &str,
@@ -1079,11 +1102,11 @@ impl UserRepository for UserPgRepository {
                 id, username, email, password_hash, role::text as role_text,
                 storage_quota_bytes, storage_used_bytes,
                 created_at, updated_at, last_login_at, active,
-                oidc_provider, oidc_subject, image, is_external,
+                federation_kind, federation_issuer, federation_subject, image, is_external,
                 given_name, family_name, email_verified_at, preferred_locale, notify_on_share,
                 ui_preferences
             FROM auth.users
-            WHERE oidc_provider = $1 AND oidc_subject = $2
+            WHERE federation_issuer = $1 AND federation_subject = $2
             "#,
         )
         .bind(provider)
@@ -1110,8 +1133,11 @@ impl UserRepository for UserPgRepository {
             row.get("updated_at"),
             row.get("last_login_at"),
             row.get("active"),
-            row.get("oidc_provider"),
-            row.get("oidc_subject"),
+            row.get::<Option<String>, _>("federation_kind")
+                .as_deref()
+                .and_then(crate::domain::entities::user::FederationKind::parse),
+            row.get("federation_issuer"),
+            row.get("federation_subject"),
             row.get("image"),
             row.get("is_external"),
             row.get("given_name"),
@@ -1367,12 +1393,12 @@ impl UserStoragePort for UserPgRepository {
             .map_err(DomainError::from)
     }
 
-    async fn get_user_by_oidc_subject(
+    async fn get_user_by_federation_subject(
         &self,
         provider: &str,
         subject: &str,
     ) -> Result<User, DomainError> {
-        UserRepository::get_user_by_oidc_subject(self, provider, subject)
+        UserRepository::get_user_by_federation_subject(self, provider, subject)
             .await
             .map_err(DomainError::from)
     }
@@ -1441,7 +1467,7 @@ mod integration_tests {
                 id, username, email, password_hash, role,
                 storage_quota_bytes, storage_used_bytes,
                 created_at, updated_at, last_login_at, active,
-                oidc_provider, is_external
+                federation_issuer, is_external
             ) VALUES (
                 $1, $2, $3, NULL, $4::auth.userrole,
                 $5, 0,
@@ -1515,7 +1541,7 @@ mod integration_tests {
         assert_eq!(page[0].storage_quota_bytes, 10_737_418_240);
         assert_eq!(page[1].username, None);
         assert!(page[1].is_external);
-        assert_eq!(page[1].oidc_provider.as_deref(), Some("integration-idp"));
+        assert_eq!(page[1].federation_issuer.as_deref(), Some("integration-idp"));
 
         let internal = UserRepository::list_user_summaries(&repo, 10, 0, false)
             .await

--- a/src/infrastructure/repositories/pg/user_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/user_pg_repository.rs
@@ -1402,6 +1402,105 @@ impl UserStoragePort for UserPgRepository {
         Ok(())
     }
 
+    async fn link_federation_identity(
+        &self,
+        user_id: Uuid,
+        kind: &str,
+        issuer: &str,
+        subject: &str,
+    ) -> Result<(), DomainError> {
+        // Guarded UPDATE: only proceed when the row currently has NO
+        // federation identity. Prevents accidental identity overwrite —
+        // callers wanting to replace an existing link must go through
+        // unlink first. Silent no-op on already-linked rows is WRONG
+        // because it would swallow the intent; instead we return an
+        // error the app service translates to `already_linked`.
+        //
+        // Uniqueness enforcement lives on `idx_users_federation`
+        // (UNIQUE(kind, issuer, subject) WHERE federation_kind IS NOT
+        // NULL). If this triple is already bound to a DIFFERENT user,
+        // the UPDATE succeeds row-count = 0 (the WHERE constrains us to
+        // rows for THIS user_id) — but the following INSERT-shaped
+        // UPDATE approach doesn't trigger the unique index; we rely on
+        // the app service having pre-checked via
+        // `get_user_by_federation_subject`. If that pre-check races
+        // with a concurrent link (rare), the second call surfaces
+        // `AlreadyExists` from sqlx via `map_sqlx_error`.
+        let result = sqlx::query(
+            r#"
+            UPDATE auth.users
+               SET federation_kind    = $2,
+                   federation_issuer  = $3,
+                   federation_subject = $4,
+                   updated_at         = NOW()
+             WHERE id = $1
+               AND federation_kind IS NULL
+            "#,
+        )
+        .bind(user_id)
+        .bind(kind)
+        .bind(issuer)
+        .bind(subject)
+        .execute(&*self.pool)
+        .await
+        .map_err(Self::map_sqlx_error)
+        .map_err(DomainError::from)?;
+
+        if result.rows_affected() == 0 {
+            // Either the user doesn't exist OR they already have a
+            // federation identity attached. The app service should have
+            // already validated user existence + link state; being here
+            // usually means a concurrent link race.
+            return Err(DomainError::already_exists(
+                "User",
+                "user is already linked to a federation identity",
+            ));
+        }
+        Ok(())
+    }
+
+    async fn is_opaque_registered(&self, user_id: Uuid) -> Result<bool, DomainError> {
+        // Scalar `IS NOT NULL` check — the envelope is a few hundred
+        // bytes of ciphertext; we don't want to fetch it just to
+        // examine presence. `fetch_optional` returns None if the user
+        // doesn't exist (caller treats missing as "not registered").
+        let row: Option<(bool,)> = sqlx::query_as(
+            r#"
+            SELECT (opaque_envelope IS NOT NULL)
+              FROM auth.users
+             WHERE id = $1
+            "#,
+        )
+        .bind(user_id)
+        .fetch_optional(&*self.pool)
+        .await
+        .map_err(Self::map_sqlx_error)
+        .map_err(DomainError::from)?;
+        Ok(row.map(|(v,)| v).unwrap_or(false))
+    }
+
+    async fn unlink_federation_identity(&self, user_id: Uuid) -> Result<(), DomainError> {
+        // Idempotent: unlinking an already-unlinked user is a zero-row
+        // UPDATE. App service's `no_alternative_auth` refusal guard
+        // runs BEFORE this — the DB layer just moves the columns.
+        sqlx::query(
+            r#"
+            UPDATE auth.users
+               SET federation_kind    = NULL,
+                   federation_issuer  = NULL,
+                   federation_subject = NULL,
+                   updated_at         = NOW()
+             WHERE id = $1
+            "#,
+        )
+        .bind(user_id)
+        .execute(&*self.pool)
+        .await
+        .map_err(Self::map_sqlx_error)
+        .map_err(DomainError::from)?;
+        Ok(())
+    }
+
     async fn list_users_by_role(&self, role: &str) -> Result<Vec<User>, DomainError> {
         UserRepository::list_users_by_role(self, role)
             .await
@@ -1574,7 +1673,10 @@ mod integration_tests {
         assert_eq!(page[0].storage_quota_bytes, 10_737_418_240);
         assert_eq!(page[1].username, None);
         assert!(page[1].is_external);
-        assert_eq!(page[1].federation_issuer.as_deref(), Some("integration-idp"));
+        assert_eq!(
+            page[1].federation_issuer.as_deref(),
+            Some("integration-idp")
+        );
 
         let internal = UserRepository::list_user_summaries(&repo, 10, 0, false)
             .await

--- a/src/infrastructure/repositories/pg/user_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/user_pg_repository.rs
@@ -498,6 +498,76 @@ impl UserRepository for UserPgRepository {
         ))
     }
 
+    /// Returns every user whose email normalizes to `normalized_email`.
+    ///
+    /// Looks up against `auth.users.identity_lookup_email`, a stored
+    /// GENERATED column populated by PostgreSQL from the same
+    /// normalization `common::text::normalize_email_for_link` applies
+    /// on the caller side. See migration
+    /// 20261011000000_users_normalized_email_index.sql — the b-tree
+    /// index on that column makes this an O(log n) probe.
+    async fn list_users_by_normalized_email(
+        &self,
+        normalized_email: &str,
+    ) -> UserRepositoryResult<Vec<User>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                id, username, email, password_hash, role::text as role_text,
+                storage_quota_bytes, storage_used_bytes,
+                created_at, updated_at, last_login_at, active,
+                federation_kind, federation_issuer, federation_subject, image, is_external,
+                given_name, family_name, email_verified_at, preferred_locale, notify_on_share,
+                ui_preferences
+            FROM auth.users
+            WHERE identity_lookup_email = $1
+            "#,
+        )
+        .bind(normalized_email)
+        .fetch_all(&*self.pool)
+        .await
+        .map_err(Self::map_sqlx_error)?;
+
+        let users = rows
+            .into_iter()
+            .map(|row| {
+                let role_str: Option<String> = row.try_get("role_text").unwrap_or(None);
+                let role = match role_str.as_deref() {
+                    Some("admin") => UserRole::Admin,
+                    _ => UserRole::User,
+                };
+                User::from_data_full(
+                    row.get("id"),
+                    row.get("username"),
+                    row.get("email"),
+                    row.get("password_hash"),
+                    role,
+                    row.get("storage_quota_bytes"),
+                    row.get("storage_used_bytes"),
+                    row.get("created_at"),
+                    row.get("updated_at"),
+                    row.get("last_login_at"),
+                    row.get("active"),
+                    row.get::<Option<String>, _>("federation_kind")
+                        .as_deref()
+                        .and_then(crate::domain::entities::user::FederationKind::parse),
+                    row.get("federation_issuer"),
+                    row.get("federation_subject"),
+                    row.get("image"),
+                    row.get("is_external"),
+                    row.get("given_name"),
+                    row.get("family_name"),
+                    row.get("email_verified_at"),
+                    row.get("preferred_locale"),
+                    row.get("notify_on_share"),
+                    row.get::<serde_json::Value, _>("ui_preferences"),
+                )
+            })
+            .collect();
+
+        Ok(users)
+    }
+
     /// Batch loads users by id in one query (avoids N+1 for group-
     /// recipient expansion). Missing ids are silently skipped — the
     /// caller treats absent rows as "no such recipient", same as
@@ -1246,6 +1316,15 @@ impl UserStoragePort for UserPgRepository {
 
     async fn get_user_by_email(&self, email: &str) -> Result<User, DomainError> {
         UserRepository::get_user_by_email(self, email)
+            .await
+            .map_err(DomainError::from)
+    }
+
+    async fn list_users_by_normalized_email(
+        &self,
+        normalized_email: &str,
+    ) -> Result<Vec<User>, DomainError> {
+        UserRepository::list_users_by_normalized_email(self, normalized_email)
             .await
             .map_err(DomainError::from)
     }

--- a/src/infrastructure/services/oidc_service.rs
+++ b/src/infrastructure/services/oidc_service.rs
@@ -180,6 +180,39 @@ impl OidcService {
         }
     }
 
+    /// Authoritative issuer URL from the IdP's discovery document —
+    /// **cache-only, non-async, non-blocking**. Returns `Some(issuer)`
+    /// when discovery has been fetched successfully before AND is not
+    /// expired; returns `None` otherwise (cold cache OR expired without
+    /// re-fetch).
+    ///
+    /// Deliberately does NOT trigger a network fetch — this is the
+    /// accessor that public endpoints (`/api/auth/oidc/providers`)
+    /// use, and driving IdP HTTP off every unauthenticated request is
+    /// a DoS amplifier. The cache gets warmed as a side-effect of
+    /// every real OIDC flow (authorize / callback / login /
+    /// validate_id_token all call `get_discovery`), so within seconds
+    /// of the first legit login this returns `Some`.
+    ///
+    /// Callers that need the definitive answer (validate_id_token, JIT
+    /// provisioning) should keep going through the async
+    /// discovery-fetching path. Callers that need a display hint
+    /// (providers endpoint) MUST use this non-async path and fall back
+    /// to a config value when it returns `None`.
+    pub fn cached_issuer(&self) -> Option<String> {
+        // try_read is non-blocking; if the cache write lock is held
+        // (extremely rare, only during a discovery refresh), we return
+        // None rather than block on public traffic.
+        let cache = self.discovery.try_read().ok()?;
+        cache.as_ref().and_then(|cached| {
+            if cached.is_expired() {
+                None
+            } else {
+                Some(cached.value.issuer.clone())
+            }
+        })
+    }
+
     /// Fetch and cache the OIDC discovery document (TTL: 1 hour)
     async fn get_discovery(&self) -> Result<OidcDiscovery, DomainError> {
         // Check cache first (return cached value only if not expired)
@@ -495,6 +528,13 @@ impl OidcServicePort for OidcService {
 
         Ok(OidcIdClaims {
             sub: claims.sub,
+            // Safe echo: jsonwebtoken::decode with
+            // `validation.set_issuer(&[&discovery.issuer])` above already
+            // enforced iss == discovery.issuer, so the discovery value
+            // IS the validated iss claim. The caller (auth service uses
+            // it for Phase B lazy-rebind) can trust this without a
+            // second validation pass.
+            iss: discovery.issuer.clone(),
             email: claims.email,
             email_verified: claims.email_verified,
             preferred_username: claims.preferred_username,
@@ -510,6 +550,11 @@ impl OidcServicePort for OidcService {
 
     async fn fetch_user_info(&self, access_token: &str) -> Result<OidcIdClaims, DomainError> {
         let discovery = self.get_discovery().await?;
+        // Capture issuer before we move `userinfo_endpoint` out below.
+        // Same rationale as validate_id_token: discovery.issuer IS the
+        // authoritative iss for this deployment; fetch_user_info is only
+        // called after a successful token exchange with this same issuer.
+        let iss = discovery.issuer.clone();
 
         let userinfo_url = discovery.userinfo_endpoint.ok_or_else(|| {
             DomainError::new(
@@ -551,6 +596,7 @@ impl OidcServicePort for OidcService {
 
         Ok(OidcIdClaims {
             sub: info.sub,
+            iss,
             email: info.email,
             email_verified: info.email_verified,
             preferred_username: info.preferred_username,
@@ -741,6 +787,7 @@ impl OidcServicePort for OidcService {
             sub: claims.sub,
             sid: claims.sid,
             jti: claims.jti,
+            iss: claims.iss,
         })
     }
 }

--- a/src/interfaces/api/handlers/auth_handler.rs
+++ b/src/interfaces/api/handlers/auth_handler.rs
@@ -51,6 +51,10 @@ pub fn auth_protected_routes() -> Router<Arc<AppState>> {
         .route("/change-password", put(change_password))
         .route("/upgrade-to-internal", post(upgrade_to_internal))
         .route("/logout", post(logout))
+        // Self-service OIDC identity linking — see
+        // docs/plan/oidc-account-linking.md.
+        .route("/oidc/link/start", post(oidc_link_start))
+        .route("/oidc/unlink", post(oidc_unlink))
 }
 
 /// Rate-limited auth routes, split out so main.rs can apply per-endpoint
@@ -1380,6 +1384,91 @@ pub async fn oidc_authorize(
     Ok(Redirect::temporary(&authorize_url))
 }
 
+/// Start a self-service OIDC linking flow for the currently-authenticated
+/// user. Returns the authorize URL for the SPA to `window.location`
+/// navigate to. Callback lands on the standard `/api/auth/oidc/callback`
+/// which dispatches to the link branch based on the state cache's
+/// `intent` field. See docs/plan/oidc-account-linking.md.
+#[utoipa::path(
+    post,
+    path = "/api/auth/oidc/link/start",
+    responses(
+        (status = 200, description = "Authorize URL to navigate the user to", body = serde_json::Value),
+        (status = 401, description = "Not authenticated"),
+        (status = 404, description = "OIDC not enabled"),
+        (status = 409, description = "User is already linked — unlink first"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "auth"
+)]
+pub async fn oidc_link_start(
+    State(state): State<Arc<AppState>>,
+    CurrentUserId(user_id): CurrentUserId,
+) -> Result<impl IntoResponse, AppError> {
+    let auth_service = state
+        .auth_service
+        .as_ref()
+        .ok_or_else(|| AppError::internal_error("Auth service not configured"))?;
+    let auth_app = &auth_service.auth_application_service;
+
+    if !auth_app.oidc_enabled() {
+        return Err(AppError::new(
+            StatusCode::NOT_FOUND,
+            "OIDC is not enabled",
+            "OidcDisabled",
+        ));
+    }
+
+    let authorize_url = auth_app.prepare_oidc_link(user_id).await?;
+
+    Ok(Json(serde_json::json!({
+        "authorize_url": authorize_url,
+    })))
+}
+
+/// Unlink the current user's OIDC identity. Refuses when the user has
+/// no other credential (password / OPAQUE) — see plan doc for the
+/// no-alternative-auth guard rationale.
+#[utoipa::path(
+    post,
+    path = "/api/auth/oidc/unlink",
+    responses(
+        (status = 200, description = "OIDC identity unlinked (or was already unlinked)"),
+        (status = 401, description = "Not authenticated"),
+        (status = 403, description = "Refused — user has no other credential and would be locked out"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "auth"
+)]
+pub async fn oidc_unlink(
+    State(state): State<Arc<AppState>>,
+    CurrentUserId(user_id): CurrentUserId,
+) -> Result<impl IntoResponse, AppError> {
+    let auth_service = state
+        .auth_service
+        .as_ref()
+        .ok_or_else(|| AppError::internal_error("Auth service not configured"))?;
+
+    // Translate the app-service's generic AccessDenied refusal into a
+    // stable machine-readable `error_type` the SPA can switch on to
+    // render the "set a password first" affordance. The app service
+    // already emits the audit line with reason=no_alternative_auth;
+    // this hop maps the domain error to a wire contract.
+    match auth_service
+        .auth_application_service
+        .unlink_oidc(user_id)
+        .await
+    {
+        Ok(()) => Ok(StatusCode::OK),
+        Err(e) if e.kind == crate::domain::errors::ErrorKind::AccessDenied => Err(AppError::new(
+            StatusCode::FORBIDDEN,
+            e.message.clone(),
+            "NoAlternativeAuth",
+        )),
+        Err(e) => Err(e.into()),
+    }
+}
+
 /// Handle the OIDC provider callback.
 ///
 /// Validates the `state` / PKCE / nonce, exchanges the code for tokens, then
@@ -1468,6 +1557,30 @@ pub async fn oidc_callback(
                 )
                 .await,
             )
+        }
+        // Self-service link flow completion — redirect the user back
+        // to their profile with a query-param signal the SPA reads on
+        // mount to render a toast + strip the param via history.
+        // See docs/plan/oidc-account-linking.md § UX flow — link.
+        OidcCallbackResult::LinkCompleted { user_id } => {
+            let config = auth_app.oidc_config().unwrap();
+            let frontend_url = config.frontend_url.trim_end_matches('/');
+            let redirect_url = format!("{}/profile?linked=1", frontend_url);
+            tracing::info!(
+                user_id = %user_id,
+                "OIDC link completed, redirecting to /profile?linked=1"
+            );
+            Ok(Redirect::temporary(&redirect_url).into_response())
+        }
+        OidcCallbackResult::LinkRefused { reason } => {
+            let config = auth_app.oidc_config().unwrap();
+            let frontend_url = config.frontend_url.trim_end_matches('/');
+            let redirect_url = format!("{}/profile?link_error={}", frontend_url, reason);
+            tracing::info!(
+                reason = reason,
+                "OIDC link refused, redirecting to /profile?link_error"
+            );
+            Ok(Redirect::temporary(&redirect_url).into_response())
         }
     }
 }

--- a/src/interfaces/api/handlers/auth_handler.rs
+++ b/src/interfaces/api/handlers/auth_handler.rs
@@ -1610,6 +1610,11 @@ pub async fn oidc_callback(
         // JSON body would leave the user staring at raw JSON. The SPA
         // login page reads `?login_error=<reason>` on mount, renders a
         // localized notice, and strips the param via history.replaceState.
+        //
+        // Reasons currently emitted (see auth_application_service.rs
+        // auto-link decision tree): auto_link_disabled,
+        // auto_link_email_not_verified, already_linked_elsewhere,
+        // email_ambiguous.
         OidcCallbackResult::AutoLinkRefused { reason } => {
             let config = auth_app.oidc_config().unwrap();
             let frontend_url = config.frontend_url.trim_end_matches('/');

--- a/src/interfaces/api/handlers/auth_handler.rs
+++ b/src/interfaces/api/handlers/auth_handler.rs
@@ -1294,6 +1294,7 @@ pub async fn oidc_providers(
     if !auth_app.oidc_enabled() {
         return Ok(Json(OidcProviderInfoDto {
             enabled: false,
+            issuer: String::new(),
             provider_name: String::new(),
             authorize_endpoint: String::new(),
             password_login_enabled,
@@ -1305,8 +1306,31 @@ pub async fn oidc_providers(
 
     let config = auth_app.oidc_config().unwrap();
 
+    // Prefer the DISCOVERY document's issuer — that's what
+    // OidcService uses to validate id_tokens AND what lands on
+    // `auth.users.federation_issuer` at JIT provisioning / lazy
+    // rebind. The config's `issuer_url` is only what the operator
+    // typed to point at discovery; the discovery document publishes
+    // the authoritative value (may differ by trailing slash, host
+    // casing, etc). **Cache-only lookup on purpose** — this
+    // endpoint is PUBLIC + UNAUTHENTICATED, so triggering an IdP
+    // HTTP fetch per request is a DoS amplifier (attacker at N req/s
+    // → we hit the IdP at N req/s, and the cache only stores on
+    // success so a degraded IdP means every call retries). On cold
+    // cache (before the first real OIDC flow warms it), fall back to
+    // the operator-typed `config.issuer_url`. In practice the cache
+    // is warm within seconds of the first login; the fallback only
+    // shows during that window and is only wrong if the IdP
+    // publishes an issuer that differs from the URL used to fetch
+    // discovery (rare in normal deployments).
+    let issuer = auth_app
+        .oidc_service()
+        .and_then(|svc| svc.cached_issuer())
+        .unwrap_or_else(|| config.issuer_url.clone());
+
     Ok(Json(OidcProviderInfoDto {
         enabled: true,
+        issuer,
         provider_name: config.provider_name.clone(),
         authorize_endpoint: "/api/auth/oidc/authorize".to_string(),
         password_login_enabled,

--- a/src/interfaces/api/handlers/auth_handler.rs
+++ b/src/interfaces/api/handlers/auth_handler.rs
@@ -1582,6 +1582,27 @@ pub async fn oidc_callback(
             );
             Ok(Redirect::temporary(&redirect_url).into_response())
         }
+        // Map each auto-link refusal reason to a distinct stable
+        // CamelCase `error_type`. The SPA switches on this to render
+        // targeted copy (contact-admin vs. verify-email-at-IdP vs.
+        // already-linked-elsewhere) rather than a generic error toast.
+        // Status stays 409 (CONFLICT) — semantically an existing user
+        // blocks the auto-provision path.
+        OidcCallbackResult::AutoLinkRefused { reason } => {
+            let error_type = match reason {
+                "auto_link_disabled" => "AutoLinkDisabled",
+                "auto_link_email_not_verified" => "AutoLinkEmailNotVerified",
+                "already_linked_elsewhere" => "AutoLinkAlreadyLinkedElsewhere",
+                _ => "AutoLinkRefused",
+            };
+            Err(AppError::new(
+                StatusCode::CONFLICT,
+                "OIDC login blocked — a local account with this email already exists. \
+                 Contact your administrator, or sign in with your existing credentials \
+                 and connect SSO from your profile.",
+                error_type,
+            ))
+        }
     }
 }
 

--- a/src/interfaces/api/handlers/auth_handler.rs
+++ b/src/interfaces/api/handlers/auth_handler.rs
@@ -1509,14 +1509,35 @@ pub async fn oidc_callback(
 
     tracing::info!("OIDC callback received with code");
 
-    // Exchange code, validate state/nonce/PKCE, authenticate user
-    let result = auth_app
+    // Exchange code, validate state/nonce/PKCE, authenticate user.
+    // Any Err path (expired state on refresh, consumed code on replay,
+    // anti-takeover email refusal, etc.) is caught below and turned
+    // into a redirect to /login?login_error=<key> — a JSON 4xx here
+    // would render as raw JSON in the browser since the caller is
+    // mid-navigation from the IdP, not the SPA. The SPA login page
+    // renders localized copy per key.
+    let result = match auth_app
         .oidc_callback(&query.code, &query.state, &state.locale_registry)
         .await
-        .map_err(|e| {
+    {
+        Ok(r) => r,
+        Err(e) => {
             tracing::error!("OIDC callback failed: {}", e);
-            AppError::from(e)
-        })?;
+            let config = auth_app.oidc_config().unwrap();
+            let frontend_url = config.frontend_url.trim_end_matches('/');
+            // AccessDenied covers the CSRF/state/code/nonce validation
+            // failures (the common "refresh replayed a consumed state"
+            // case). Everything else is bucketed as a generic callback
+            // failure — operators dig into the log line above for the
+            // specifics; end-users only need "try again" guidance.
+            let reason = match e.kind {
+                crate::domain::errors::ErrorKind::AccessDenied => "callback_denied",
+                _ => "callback_failed",
+            };
+            let redirect_url = format!("{}/login?login_error={}", frontend_url, reason);
+            return Ok(Redirect::temporary(&redirect_url).into_response());
+        }
+    };
 
     match result {
         OidcCallbackResult::WebLogin { exchange_code } => {
@@ -1582,26 +1603,22 @@ pub async fn oidc_callback(
             );
             Ok(Redirect::temporary(&redirect_url).into_response())
         }
-        // Map each auto-link refusal reason to a distinct stable
-        // CamelCase `error_type`. The SPA switches on this to render
-        // targeted copy (contact-admin vs. verify-email-at-IdP vs.
-        // already-linked-elsewhere) rather than a generic error toast.
-        // Status stays 409 (CONFLICT) — semantically an existing user
-        // blocks the auto-provision path.
+        // Redirect the browser back to the login page with a
+        // machine-readable reason on the query string, mirroring the
+        // LinkRefused → `/profile?link_error=<reason>` pattern above.
+        // The browser is mid-redirect from the IdP; returning a 409
+        // JSON body would leave the user staring at raw JSON. The SPA
+        // login page reads `?login_error=<reason>` on mount, renders a
+        // localized notice, and strips the param via history.replaceState.
         OidcCallbackResult::AutoLinkRefused { reason } => {
-            let error_type = match reason {
-                "auto_link_disabled" => "AutoLinkDisabled",
-                "auto_link_email_not_verified" => "AutoLinkEmailNotVerified",
-                "already_linked_elsewhere" => "AutoLinkAlreadyLinkedElsewhere",
-                _ => "AutoLinkRefused",
-            };
-            Err(AppError::new(
-                StatusCode::CONFLICT,
-                "OIDC login blocked — a local account with this email already exists. \
-                 Contact your administrator, or sign in with your existing credentials \
-                 and connect SSO from your profile.",
-                error_type,
-            ))
+            let config = auth_app.oidc_config().unwrap();
+            let frontend_url = config.frontend_url.trim_end_matches('/');
+            let redirect_url = format!("{}/login?login_error={}", frontend_url, reason);
+            tracing::info!(
+                reason = reason,
+                "OIDC auto-link refused, redirecting to /login?login_error"
+            );
+            Ok(Redirect::temporary(&redirect_url).into_response())
         }
     }
 }

--- a/src/interfaces/api/mod.rs
+++ b/src/interfaces/api/mod.rs
@@ -80,6 +80,8 @@ use crate::interfaces::api::handlers::file_handler::MoveFilePayload;
         handlers::auth_handler::oidc_callback,
         handlers::auth_handler::oidc_exchange,
         handlers::auth_handler::oidc_backchannel_logout,
+        handlers::auth_handler::oidc_link_start,
+        handlers::auth_handler::oidc_unlink,
         // File handlers (free functions — see file_handler.rs for why)
         handlers::file_handler::list_files_query,
         handlers::file_handler::upload_file_with_thumbnails,

--- a/src/interfaces/nextcloud/ocs_handler.rs
+++ b/src/interfaces/nextcloud/ocs_handler.rs
@@ -213,8 +213,14 @@ async fn user_provisioning_response(
         vec!["users"]
     };
 
-    // Determine backend based on auth provider
-    let backend = if user_dto.auth_provider.to_lowercase().contains("oidc") {
+    // Determine backend based on federation kind. Historically checked
+    // `auth_provider.to_lowercase().contains("oidc")` which happened to
+    // work when the DTO field held a display label containing "oidc"
+    // (e.g. "OIDC-Google") — but broke silently when the label was
+    // "MockSSO" or, post Phase B of the federation-identity rename, when
+    // the field became an issuer URL that doesn't contain "oidc". The
+    // kind field is the load-bearing signal.
+    let backend = if user_dto.federation_kind.as_deref() == Some("oidc") {
         "OIDC"
     } else {
         "Database"

--- a/tests/oidc/fake_idp/server.js
+++ b/tests/oidc/fake_idp/server.js
@@ -84,6 +84,17 @@ let emailVerifiedState = true;
 // setting to the pinned value explicitly).
 let emailOverride = null;
 
+// Runtime-swappable sub (subject / accountId) — normally TEST_USER_SUB,
+// overridable via `POST /control/set-sub` to test the OIDC-linking
+// scenarios that need a fresh, not-yet-known federated identity:
+// self-service link happy path, +alias normalization link, auto-link
+// happy path, auto-link refusal (verified=false). The set-sub endpoint
+// ALSO clears the OP's session cookies in the response — otherwise
+// the next authorize dance would reuse the previously-established
+// session bound to the OLD sub and skip the login prompt (where the
+// new sub gets bound). Reset by POSTing an empty/null body.
+let subOverride = null;
+
 // Pre-generate the signing keypair. oidc-provider v9 accepts private
 // JWKs via configuration.jwks and exports the public halves at
 // /jwks.json; keeping our own reference to the private key means we
@@ -162,7 +173,8 @@ const configuration = {
   },
 
   async findAccount(_ctx, sub) {
-    if (sub !== TEST_USER_SUB) return undefined;
+    const currentSub = subOverride ?? TEST_USER_SUB;
+    if (sub !== currentSub) return undefined;
     return {
       accountId: sub,
       // Return EVERY claim the OIDC client could ask for. The provider
@@ -170,7 +182,7 @@ const configuration = {
       // a granted scope are dropped from the ID token / userinfo.
       async claims() {
         return {
-          sub: TEST_USER_SUB,
+          sub: currentSub,
           email: emailOverride ?? TEST_USER_EMAIL,
           email_verified: emailVerifiedState,
           name: TEST_USER_NAME,
@@ -256,6 +268,52 @@ async function handleControl(req, res) {
     res.statusCode = 200;
     res.setHeader('content-type', 'application/json');
     return res.end(JSON.stringify({ email_verified: false }));
+  }
+  // Swap the IdP-returned sub (accountId) to test the OIDC-linking
+  // scenarios that need a fresh, not-yet-known identity: self-service
+  // link happy path, +alias normalization link, auto-link happy path,
+  // auto-link refusal (email_verified=false).
+  //
+  // Body: `{ sub: "sub-link-happy" }` — or `null`/`""` to reset to
+  // the pinned TEST_USER_SUB.
+  //
+  // ALSO clears the OP's session cookies via Set-Cookie in the
+  // response. Without this, the next authorize dance from the same
+  // Hurl file (same cookie jar) would reuse the previously-established
+  // session — bound to the OLD sub — and skip the login prompt where
+  // the new sub gets bound. Panva/node-oidc-provider defaults for the
+  // session/grant/interaction cookies are documented in
+  // https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#cookies
+  // — we clear the ones the client-side cookie jar can hold.
+  if (req.method === 'POST' && url.pathname === '/control/set-sub') {
+    let body = '';
+    for await (const chunk of req) body += chunk;
+    let parsed = {};
+    try {
+      parsed = body ? JSON.parse(body) : {};
+    } catch {
+      res.statusCode = 400;
+      res.setHeader('content-type', 'application/json');
+      return res.end(JSON.stringify({ error: 'invalid_json' }));
+    }
+    subOverride =
+      parsed.sub && typeof parsed.sub === 'string' && parsed.sub.length > 0
+        ? parsed.sub
+        : null;
+    res.statusCode = 200;
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('Set-Cookie', [
+      '_session=; Path=/; Max-Age=0; HttpOnly',
+      '_session.legacy=; Path=/; Max-Age=0; HttpOnly',
+      '_grant=; Path=/; Max-Age=0; HttpOnly',
+      '_interaction=; Path=/; Max-Age=0; HttpOnly',
+    ]);
+    return res.end(
+      JSON.stringify({
+        sub: subOverride ?? TEST_USER_SUB,
+        overridden: subOverride !== null,
+      }),
+    );
   }
   // Swap the IdP-returned email to test the OIDC-account-linking
   // safety checks (email match, +alias normalization, mismatch refusal).
@@ -406,14 +464,14 @@ async function handleAuto(req, res) {
     return provider.interactionFinished(
       req,
       res,
-      { login: { accountId: TEST_USER_SUB } },
+      { login: { accountId: subOverride ?? TEST_USER_SUB } },
       { mergeWithLastSubmission: false },
     );
   }
 
   if (name === 'consent') {
     const grant = new provider.Grant({
-      accountId: TEST_USER_SUB,
+      accountId: subOverride ?? TEST_USER_SUB,
       clientId: params.client_id,
     });
     if (params.scope) grant.addOIDCScope(params.scope);

--- a/tests/oidc/fake_idp/server.js
+++ b/tests/oidc/fake_idp/server.js
@@ -76,6 +76,14 @@ const BCL_EVENT = 'http://schemas.openid.net/event/backchannel-logout';
 // claims() callback.
 let emailVerifiedState = true;
 
+// Runtime-swappable email — normally the pinned TEST_USER_EMAIL, but
+// the OIDC-account-linking Hurl suite flips it via
+// `POST /control/set-email` to test the auto-link + self-service-link
+// safety checks: email mismatch refusal, +alias normalization
+// equivalence, etc. Reset by `POST /control/reset-email` (or by
+// setting to the pinned value explicitly).
+let emailOverride = null;
+
 // Pre-generate the signing keypair. oidc-provider v9 accepts private
 // JWKs via configuration.jwks and exports the public halves at
 // /jwks.json; keeping our own reference to the private key means we
@@ -163,7 +171,7 @@ const configuration = {
       async claims() {
         return {
           sub: TEST_USER_SUB,
-          email: TEST_USER_EMAIL,
+          email: emailOverride ?? TEST_USER_EMAIL,
           email_verified: emailVerifiedState,
           name: TEST_USER_NAME,
           given_name: TEST_USER_GIVEN_NAME,
@@ -248,6 +256,34 @@ async function handleControl(req, res) {
     res.statusCode = 200;
     res.setHeader('content-type', 'application/json');
     return res.end(JSON.stringify({ email_verified: false }));
+  }
+  // Swap the IdP-returned email to test the OIDC-account-linking
+  // safety checks (email match, +alias normalization, mismatch refusal).
+  // Body: `{ email: "alice@example.com" }` — or `null`/`""` to reset
+  // to the pinned TEST_USER_EMAIL.
+  if (req.method === 'POST' && url.pathname === '/control/set-email') {
+    let body = '';
+    for await (const chunk of req) body += chunk;
+    let parsed = {};
+    try {
+      parsed = body ? JSON.parse(body) : {};
+    } catch {
+      res.statusCode = 400;
+      res.setHeader('content-type', 'application/json');
+      return res.end(JSON.stringify({ error: 'invalid_json' }));
+    }
+    emailOverride =
+      parsed.email && typeof parsed.email === 'string' && parsed.email.length > 0
+        ? parsed.email
+        : null;
+    res.statusCode = 200;
+    res.setHeader('content-type', 'application/json');
+    return res.end(
+      JSON.stringify({
+        email: emailOverride ?? TEST_USER_EMAIL,
+        overridden: emailOverride !== null,
+      }),
+    );
   }
   if (req.method === 'POST' && url.pathname === '/control/backchannel-logout') {
     // Body shape: `{ sub?: string, sid?: string }`. Optional so the test

--- a/tests/oidc/link_unlink.hurl
+++ b/tests/oidc/link_unlink.hurl
@@ -40,8 +40,9 @@
 #        (iss, sub) miss but email matches admin, so it auto-
 #        links + logs admin in.
 #     2. Auto-link refused — email_verified=false. Callback
-#        returns HTTP 409 with error_type "Already Exists" (the
-#        "contact admin to link your OIDC identity" refusal).
+#        returns HTTP 409 with error_type "AutoLinkEmailNotVerified"
+#        (one of three distinct auto-link refusal error_types —
+#        see auth_handler.rs AutoLinkRefused arm).
 #
 #   [OIDC-only user]
 #    10. `oidc_user` unlink refused (would lock them out) with
@@ -491,12 +492,10 @@ HTTP 200
 # "contact admin to link your OIDC identity" text that surfaces
 # in the SPA login form's error toast.
 #
-# NOTE: `error_type` here is "Already Exists" (with a space)
-# because it comes from `ErrorKind::as_str()`, not from a
-# handler-set stable key. The auto-link refusal branch is
-# reusing the generic AlreadyExists mapping — a follow-up
-# could give it a dedicated `error_type` like
-# `AutoLinkEmailNotVerified` for the SPA to switch on.
+# The handler maps each auto-link refusal reason to a distinct
+# CamelCase error_type — AutoLinkDisabled /
+# AutoLinkEmailNotVerified / AutoLinkAlreadyLinkedElsewhere —
+# so the SPA can render targeted copy per refusal reason.
 # ═════════════════════════════════════════════════════════════
 
 
@@ -522,7 +521,10 @@ location-trusted: true
 
 HTTP 409
 [Asserts]
-jsonpath "$.error_type" == "Already Exists"
+# Distinct CamelCase key per auto-link refusal reason — the SPA
+# switches on this to render "verify your email at the IdP" copy
+# rather than the generic contact-admin fallback.
+jsonpath "$.error_type" == "AutoLinkEmailNotVerified"
 
 
 # Belt-and-braces invariant: admin's row is still un-linked

--- a/tests/oidc/link_unlink.hurl
+++ b/tests/oidc/link_unlink.hurl
@@ -47,18 +47,18 @@
 #        the self-service link flow. See auth_handler.rs
 #        AutoLinkRefused arm.
 #
+#     3. Auto-link refused — email_ambiguous. Admin creates a
+#        second local user whose email `admin+work@example.com`
+#        normalizes to the same key as admin's `admin@example.com`.
+#        The fake IdP then returns `admin@example.com` for a fresh
+#        sub; auto-link's normalized fan-out finds >1 candidate
+#        and refuses via /login?login_error=email_ambiguous.
+#        Cleans up the second user afterwards so subsequent
+#        scenarios aren't affected.
+#
 #   [OIDC-only user]
 #    10. `oidc_user` unlink refused (would lock them out) with
 #        error_type NoAlternativeAuth.
-#
-# NOT covered (backend gap; not a Hurl gap):
-#   3. Auto-link refused — email_ambiguous. The current
-#      auto-link path uses `get_user_by_email` (exact match),
-#      not a normalized-email lookup. It CAN'T see two rows
-#      normalizing to the same value, so the ambiguity branch
-#      in the plan doc is unreachable from wire input. Needs a
-#      `list_users_by_normalized_email` repo method before
-#      Hurl can exercise it — separate PR.
 #
 # NOT covered (config gap; would need a second server boot):
 #   4. Auto-link disabled by OXICLOUD_OIDC_AUTO_LINK_EMAIL_MATCH=false.
@@ -566,7 +566,107 @@ HTTP 200
 
 
 # ═════════════════════════════════════════════════════════════
-# Step 11 (Scenario 10) — Unlink refused for the OIDC-only user.
+# Step 11 (Scenario 3) — Auto-link refused, email_ambiguous.
+# ═════════════════════════════════════════════════════════════
+# Create a second local user whose email normalizes to admin's.
+# `admin@example.com` and `alice+work@admin_example.com` don't
+# collide; we need `admin+work@example.com` — same local base
+# and same domain as admin. Then the fake IdP returns
+# `admin@example.com` (verified) for a fresh sub. The auto-link
+# decision tree's list_users_by_normalized_email finds 2
+# candidates → refuses `email_ambiguous` → callback redirects to
+# /login?login_error=email_ambiguous. Both local rows survive
+# untouched (no auto-link happens on either).
+#
+# Cleanup at the tail deletes the second user so subsequent
+# scenarios see the same starting state (admin unlinked, no
+# stray federation candidates).
+# ═════════════════════════════════════════════════════════════
+
+
+# Create the collider. `autolink_csrf_token` from Step 9 is still
+# valid — admin session cookies haven't rotated since (Step 10's
+# refused callback set no new cookies).
+POST {{base_url}}/api/admin/users
+Content-Type: application/json
+X-CSRF-Token: {{autolink_csrf_token}}
+{
+  "username": "admin_alias",
+  "email": "admin+work@example.com",
+  "password": "TestPassword1!",
+  "role": "user"
+}
+
+HTTP 201
+[Captures]
+alias_user_id: jsonpath "$.id"
+
+
+# Point the fake IdP at a fresh sub with admin's email. Both
+# admin@example.com and admin+work@example.com normalize to
+# admin@example.com — auto-link must see both and refuse.
+POST {{oidc_issuer}}/control/set-sub
+Content-Type: application/json
+{ "sub": "sub-ambiguous" }
+
+HTTP 200
+
+
+POST {{oidc_issuer}}/control/set-email
+Content-Type: application/json
+{ "email": "{{email}}" }
+
+HTTP 200
+
+
+GET {{base_url}}/api/auth/oidc/authorize
+[Options]
+location: true
+location-trusted: true
+
+HTTP 200
+[Asserts]
+url matches "^http://localhost:8087/login\\?login_error=email_ambiguous$"
+
+
+# Belt-and-braces invariant: neither admin nor admin_alias got
+# federation columns populated. The refusal fires BEFORE
+# link_federation_identity.
+GET {{base_url}}/api/auth/me
+
+HTTP 200
+[Asserts]
+jsonpath "$.federation_kind" not exists
+
+
+# Cleanup — delete the collider so later scenarios see the same
+# initial state. Uses the current admin session cookies + CSRF.
+DELETE {{base_url}}/api/admin/users/{{alias_user_id}}
+X-CSRF-Token: {{autolink_csrf_token}}
+
+HTTP *
+[Asserts]
+status < 400
+
+
+# Reset IdP back to defaults before the oidc_user re-login step
+# (which needs the real TEST_USER_SUB + oidc@example.com).
+POST {{oidc_issuer}}/control/set-sub
+Content-Type: application/json
+{}
+
+HTTP 200
+
+
+POST {{oidc_issuer}}/control/set-email
+Content-Type: application/json
+{}
+
+HTTP 200
+
+
+# ═════════════════════════════════════════════════════════════
+# Step 12 (Scenario 10) — Unlink refused for the OIDC-only user.
 # ═════════════════════════════════════════════════════════════
 # Fresh OIDC login as `oidc_user` (the JIT-provisioned
 # federated principal from oidc.hurl). Uses the reset default

--- a/tests/oidc/link_unlink.hurl
+++ b/tests/oidc/link_unlink.hurl
@@ -40,9 +40,12 @@
 #        (iss, sub) miss but email matches admin, so it auto-
 #        links + logs admin in.
 #     2. Auto-link refused — email_verified=false. Callback
-#        returns HTTP 409 with error_type "AutoLinkEmailNotVerified"
-#        (one of three distinct auto-link refusal error_types —
-#        see auth_handler.rs AutoLinkRefused arm).
+#        redirects the browser to
+#        /login?login_error=auto_link_email_not_verified so the
+#        SPA login page can render a localized notice. Sibling
+#        of the /profile?link_error=<reason> redirect used by
+#        the self-service link flow. See auth_handler.rs
+#        AutoLinkRefused arm.
 #
 #   [OIDC-only user]
 #    10. `oidc_user` unlink refused (would lock them out) with
@@ -512,19 +515,18 @@ HTTP 200
 
 
 # Follow the whole OIDC dance. Hurl's location: true follows 3xx
-# up to the callback; the callback returns 409 (non-3xx) and
-# location follow stops. The final response is what we assert on.
+# up to the callback; the callback redirects to /login with a
+# machine-readable reason on the query string, and the SPA login
+# page lands at 200 (index.html fallback). Assert on URL, since
+# that's the load-bearing wire contract the SPA reads on mount.
 GET {{base_url}}/api/auth/oidc/authorize
 [Options]
 location: true
 location-trusted: true
 
-HTTP 409
+HTTP 200
 [Asserts]
-# Distinct CamelCase key per auto-link refusal reason — the SPA
-# switches on this to render "verify your email at the IdP" copy
-# rather than the generic contact-admin fallback.
-jsonpath "$.error_type" == "AutoLinkEmailNotVerified"
+url matches "^http://localhost:8087/login\\?login_error=auto_link_email_not_verified$"
 
 
 # Belt-and-braces invariant: admin's row is still un-linked

--- a/tests/oidc/link_unlink.hurl
+++ b/tests/oidc/link_unlink.hurl
@@ -1,0 +1,191 @@
+# =============================================================
+# OxiCloud — OIDC account link / unlink coverage
+# =============================================================
+# Complements tests/oidc/oidc.hurl (which exercises the login
+# flow end-to-end). This file focuses on the self-service link
+# and unlink flows introduced by
+# docs/plan/oidc-account-linking.md. It runs AFTER oidc.hurl in
+# the OIDC suite so the fake-IdP + OxiCloud server are already
+# up.
+#
+# Scenarios covered here:
+#   1. Auto-link on OIDC login when an existing local user's
+#      email matches the IdP-returned email + email_verified=true.
+#   2. Unlink success — local admin unlinks their OIDC identity.
+#   3. Unlink refused when no alternative auth is available.
+#
+# NOT covered (documented in the plan doc, follow-up work):
+#   - Self-service link/unlink via `POST /api/auth/oidc/link/start`
+#     from an authenticated session (browser-driven flow;
+#     Hurl-simulating the two-hop authorize dance from an
+#     already-authenticated session with cookies is doable but
+#     larger than the current scope).
+#   - Email mismatch refusal (needs `/control/set-email` on the
+#     fake IdP + a follow-through OIDC flow to prove refusal).
+#   - +alias normalization equivalence.
+#   - Ambiguous-email refusal (needs two OxiCloud users
+#     normalizing to the same email).
+# =============================================================
+
+
+# ─────────────────────────────────────────────────────────────
+# Preflight: capture the admin id from an earlier oidc.hurl step
+# is not possible across files, so we re-fetch by logging in as
+# the local admin the setup step created.
+#
+# The admin's email was set by tests/oidc/test.env as
+# `admin@example.com` — deliberately DIFFERENT from the fake IdP's
+# TEST_USER_EMAIL (`oidc@example.com`), so the earlier OIDC login
+# flow JIT-provisioned a fresh `oidc_user` instead of auto-linking
+# to admin. We reuse that oidc_user here.
+#
+# The oidc_user was created via JIT during oidc.hurl, so it EXISTS
+# and is OIDC-linked (`federation_kind='oidc'`). We can:
+#   1. Assert /api/admin/users/by-username shows oidc_user is linked.
+#   2. Log in as admin (local password) → POST unlink for admin
+#      → verify refused because admin has no federation link.
+#   3. As the OIDC-linked oidc_user (needs a fresh OIDC login),
+#      test unlink refusal (oidc_user has no password/OPAQUE).
+#
+# For the FIRST ship we run a minimal end-to-end check that
+# proves the endpoints route correctly, the safety-check refusal
+# fires, and unlinking without alt-auth returns 403.
+# ─────────────────────────────────────────────────────────────
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 1 — Log in as local admin (password auth path)
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/auth/login
+Content-Type: application/json
+{
+  "username": "{{username}}",
+  "password": "{{password}}"
+}
+
+HTTP 200
+[Captures]
+admin_access_token: cookie "oxicloud_access"
+# Capture the double-submit CSRF cookie the SPA reads and mirrors
+# into the X-CSRF-Token header on every mutating request. Every
+# authenticated POST/PATCH/PUT/DELETE below MUST include the header
+# or hit CSRF middleware refusal (403).
+admin_csrf_token: cookie "oxicloud_csrf"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 2 — Admin is NOT federated; /api/auth/me shows federation
+#          fields absent (null / omitted).
+# ─────────────────────────────────────────────────────────────
+GET {{base_url}}/api/auth/me
+
+HTTP 200
+[Asserts]
+jsonpath "$.username" == "{{username}}"
+# federation_kind is skip_serializing_if=Option::is_none, so a
+# local user's response OMITS the field entirely.
+jsonpath "$.federation_kind" not exists
+jsonpath "$.federation_issuer" not exists
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 3 — Admin starts a self-service link flow. Returns an
+#          authorize URL that would take them to the IdP. We
+#          don't follow the redirect here (the round-trip IS
+#          exercised by tests/oidc/oidc.hurl's login flow); this
+#          asserts the endpoint routes correctly and returns the
+#          expected shape.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/auth/oidc/link/start
+Content-Type: application/json
+X-CSRF-Token: {{admin_csrf_token}}
+{}
+
+HTTP 200
+[Asserts]
+# The authorize URL points at the fake IdP with the OAuth2 dance.
+jsonpath "$.authorize_url" matches "^{{oidc_issuer}}/auth\\?response_type=code&"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 4 — Admin has a local password, so unlinking is SAFE
+#          (no alt-auth guard triggers). But admin isn't linked,
+#          so the unlink is a NO-OP success (idempotent).
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/auth/oidc/unlink
+Content-Type: application/json
+X-CSRF-Token: {{admin_csrf_token}}
+{}
+
+HTTP 200
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 5 — Fresh OIDC login as oidc_user (the JIT-provisioned
+#          federated user). Uses the same authorize → callback →
+#          exchange dance as oidc.hurl Step 9 (existing-user
+#          re-login).
+# ─────────────────────────────────────────────────────────────
+GET {{base_url}}/api/auth/oidc/authorize
+[Options]
+location: false
+
+HTTP 307
+[Captures]
+oidc_idp_url: header "Location"
+
+
+GET {{oidc_idp_url}}
+[Options]
+location: true
+location-trusted: true
+
+HTTP 200
+[Captures]
+oidc_code: url regex "oidc_code=([a-f0-9]+)"
+
+
+POST {{base_url}}/api/auth/oidc/exchange
+Content-Type: application/json
+{ "code": "{{oidc_code}}" }
+
+HTTP 200
+[Asserts]
+jsonpath "$.user.username" == "oidc_user"
+jsonpath "$.user.federation_kind" == "oidc"
+[Captures]
+oidc_user_access_token: cookie "oxicloud_access"
+# Fresh CSRF from the OIDC session cookies — the previous
+# admin_csrf_token was for the admin session and won't validate
+# against these new cookies.
+oidc_user_csrf_token: cookie "oxicloud_csrf"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 6 — oidc_user attempts to unlink. Refused because the JIT
+#          user has NO password and NO OPAQUE envelope — unlinking
+#          would lock them out. The backend guard fires with
+#          reason=no_alternative_auth → 403.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/auth/oidc/unlink
+Content-Type: application/json
+X-CSRF-Token: {{oidc_user_csrf_token}}
+{}
+
+HTTP 403
+[Asserts]
+# error_type is the stable machine-readable key the SPA switches
+# on to render the "set a password first" affordance.
+jsonpath "$.error_type" == "NoAlternativeAuth"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 7 — Verify unlink was refused: /me still shows the OIDC
+#          identity linked.
+# ─────────────────────────────────────────────────────────────
+GET {{base_url}}/api/auth/me
+
+HTTP 200
+[Asserts]
+jsonpath "$.federation_kind" == "oidc"
+jsonpath "$.federation_issuer" == "{{oidc_issuer}}"

--- a/tests/oidc/link_unlink.hurl
+++ b/tests/oidc/link_unlink.hurl
@@ -8,53 +8,70 @@
 # the OIDC suite so the fake-IdP + OxiCloud server are already
 # up.
 #
-# Scenarios covered here:
-#   1. Auto-link on OIDC login when an existing local user's
-#      email matches the IdP-returned email + email_verified=true.
-#   2. Unlink success — local admin unlinks their OIDC identity.
-#   3. Unlink refused when no alternative auth is available.
+# ENTRY STATE (post-oidc.hurl):
+#   * `admin` — local, password auth, email admin@example.com,
+#     NOT federation-linked.
+#   * `oidc_user` — JIT-provisioned, federation_kind='oidc',
+#     issuer=<fake_idp>, subject=oidc-test-user, email
+#     oidc@example.com, NO password / NO OPAQUE.
+#   * Fake IdP — subOverride=null, emailOverride=null,
+#     verified=true, accountId=`oidc-test-user`.
 #
-# NOT covered (documented in the plan doc, follow-up work):
-#   - Self-service link/unlink via `POST /api/auth/oidc/link/start`
-#     from an authenticated session (browser-driven flow;
-#     Hurl-simulating the two-hop authorize dance from an
-#     already-authenticated session with cookies is doable but
-#     larger than the current scope).
-#   - Email mismatch refusal (needs `/control/set-email` on the
-#     fake IdP + a follow-through OIDC flow to prove refusal).
-#   - +alias normalization equivalence.
-#   - Ambiguous-email refusal (needs two OxiCloud users
-#     normalizing to the same email).
+# Scenarios covered here (indexed against
+# docs/plan/oidc-account-linking.md § Hurl test coverage):
+#
+#   [Refusals on the default sub]
+#     — Self-service link routing: POST /link/start returns the
+#       expected authorize URL.
+#     — Unlink idempotency: POST /unlink on an unlinked user is
+#       a 200 no-op.
+#     6. Self-service link email_mismatch (default email vs admin).
+#     8. Self-service link already_linked_elsewhere (email swapped
+#        to admin's, but the sub is still linked to oidc_user).
+#
+#   [Fresh subs — needs /control/set-sub on the fake IdP]
+#     5. Self-service link happy round-trip → /profile?linked=1
+#        + /me shows the federation identity. Then unlink and
+#        assert federation cleared (scenario 9).
+#     7. +alias normalization link — IdP returns
+#        `admin+oidc@example.com` which normalizes to admin's
+#        `admin@example.com`. Link succeeds.
+#     1. Auto-link happy path — OIDC login callback sees a
+#        (iss, sub) miss but email matches admin, so it auto-
+#        links + logs admin in.
+#     2. Auto-link refused — email_verified=false. Callback
+#        returns HTTP 409 with error_type "Already Exists" (the
+#        "contact admin to link your OIDC identity" refusal).
+#
+#   [OIDC-only user]
+#    10. `oidc_user` unlink refused (would lock them out) with
+#        error_type NoAlternativeAuth.
+#
+# NOT covered (backend gap; not a Hurl gap):
+#   3. Auto-link refused — email_ambiguous. The current
+#      auto-link path uses `get_user_by_email` (exact match),
+#      not a normalized-email lookup. It CAN'T see two rows
+#      normalizing to the same value, so the ambiguity branch
+#      in the plan doc is unreachable from wire input. Needs a
+#      `list_users_by_normalized_email` repo method before
+#      Hurl can exercise it — separate PR.
+#
+# NOT covered (config gap; would need a second server boot):
+#   4. Auto-link disabled by OXICLOUD_OIDC_AUTO_LINK_EMAIL_MATCH=false.
+#      Server boots with the flag ON in server-with-oidc.env;
+#      testing the OFF branch means a separate hurl invocation
+#      with a re-launched server, which the current run.sh does
+#      not do.
 # =============================================================
 
 
 # ─────────────────────────────────────────────────────────────
-# Preflight: capture the admin id from an earlier oidc.hurl step
-# is not possible across files, so we re-fetch by logging in as
-# the local admin the setup step created.
+# Step 1 — Log in as local admin (password auth path).
 #
-# The admin's email was set by tests/oidc/test.env as
-# `admin@example.com` — deliberately DIFFERENT from the fake IdP's
-# TEST_USER_EMAIL (`oidc@example.com`), so the earlier OIDC login
-# flow JIT-provisioned a fresh `oidc_user` instead of auto-linking
-# to admin. We reuse that oidc_user here.
-#
-# The oidc_user was created via JIT during oidc.hurl, so it EXISTS
-# and is OIDC-linked (`federation_kind='oidc'`). We can:
-#   1. Assert /api/admin/users/by-username shows oidc_user is linked.
-#   2. Log in as admin (local password) → POST unlink for admin
-#      → verify refused because admin has no federation link.
-#   3. As the OIDC-linked oidc_user (needs a fresh OIDC login),
-#      test unlink refusal (oidc_user has no password/OPAQUE).
-#
-# For the FIRST ship we run a minimal end-to-end check that
-# proves the endpoints route correctly, the safety-check refusal
-# fires, and unlinking without alt-auth returns 403.
-# ─────────────────────────────────────────────────────────────
-
-
-# ─────────────────────────────────────────────────────────────
-# Step 1 — Log in as local admin (password auth path)
+# Captures the double-submit CSRF cookie the SPA reads and
+# mirrors into the X-CSRF-Token header on every mutating
+# request. Every authenticated POST/PATCH/PUT/DELETE below
+# MUST include the header or hit CSRF middleware refusal (403).
 # ─────────────────────────────────────────────────────────────
 POST {{base_url}}/api/auth/login
 Content-Type: application/json
@@ -66,10 +83,6 @@ Content-Type: application/json
 HTTP 200
 [Captures]
 admin_access_token: cookie "oxicloud_access"
-# Capture the double-submit CSRF cookie the SPA reads and mirrors
-# into the X-CSRF-Token header on every mutating request. Every
-# authenticated POST/PATCH/PUT/DELETE below MUST include the header
-# or hit CSRF middleware refusal (403).
 admin_csrf_token: cookie "oxicloud_csrf"
 
 
@@ -89,12 +102,10 @@ jsonpath "$.federation_issuer" not exists
 
 
 # ─────────────────────────────────────────────────────────────
-# Step 3 — Admin starts a self-service link flow. Returns an
-#          authorize URL that would take them to the IdP. We
-#          don't follow the redirect here (the round-trip IS
-#          exercised by tests/oidc/oidc.hurl's login flow); this
-#          asserts the endpoint routes correctly and returns the
-#          expected shape.
+# Step 3 — Routing check for /link/start. Returns the authorize
+#          URL the SPA would use to full-page-navigate to the
+#          IdP. We don't follow it here; scenarios below own
+#          the round-trip.
 # ─────────────────────────────────────────────────────────────
 POST {{base_url}}/api/auth/oidc/link/start
 Content-Type: application/json
@@ -103,14 +114,14 @@ X-CSRF-Token: {{admin_csrf_token}}
 
 HTTP 200
 [Asserts]
-# The authorize URL points at the fake IdP with the OAuth2 dance.
 jsonpath "$.authorize_url" matches "^{{oidc_issuer}}/auth\\?response_type=code&"
 
 
 # ─────────────────────────────────────────────────────────────
-# Step 4 — Admin has a local password, so unlinking is SAFE
-#          (no alt-auth guard triggers). But admin isn't linked,
-#          so the unlink is a NO-OP success (idempotent).
+# Step 4 — Idempotent unlink on an unlinked user is a 200 no-op.
+#          Admin has a local password, so the no_alternative_auth
+#          guard wouldn't fire even if there were something to
+#          unlink.
 # ─────────────────────────────────────────────────────────────
 POST {{base_url}}/api/auth/oidc/unlink
 Content-Type: application/json
@@ -120,12 +131,447 @@ X-CSRF-Token: {{admin_csrf_token}}
 HTTP 200
 
 
-# ─────────────────────────────────────────────────────────────
-# Step 5 — Fresh OIDC login as oidc_user (the JIT-provisioned
-#          federated user). Uses the same authorize → callback →
-#          exchange dance as oidc.hurl Step 9 (existing-user
-#          re-login).
-# ─────────────────────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════
+# Step 5 (Scenario 6) — Self-service link, email_mismatch refusal.
+# ═════════════════════════════════════════════════════════════
+# Default fake-IdP state (emailOverride=null) returns
+# oidc@example.com — which does NOT match admin's
+# admin@example.com. The callback recognises the Link intent,
+# runs the email normalization comparison, and refuses with
+# `email_mismatch`.
+#
+# Wire contract: 307 to `/profile?link_error=email_mismatch`.
+# With `location: true` Hurl follows the full chain (authorize
+# → IdP login+consent auto-approve → callback → redirect) and
+# lands on the SPA-served /profile page (status 200 — the
+# `index.html` fallback serves any client-router path).
+# Assertion pins the exact URL shape the SPA reads on mount.
+# ═════════════════════════════════════════════════════════════
+
+
+# Belt-and-braces: reset any subOverride / emailOverride that
+# might have leaked from an earlier suite (defensive — oidc.hurl
+# doesn't use them, but a re-used fake-idp process could).
+POST {{oidc_issuer}}/control/set-sub
+Content-Type: application/json
+{}
+
+HTTP 200
+
+
+POST {{oidc_issuer}}/control/set-email
+Content-Type: application/json
+{}
+
+HTTP 200
+
+
+POST {{base_url}}/api/auth/oidc/link/start
+Content-Type: application/json
+X-CSRF-Token: {{admin_csrf_token}}
+{}
+
+HTTP 200
+[Captures]
+mismatch_authorize_url: jsonpath "$.authorize_url"
+
+
+GET {{mismatch_authorize_url}}
+[Options]
+location: true
+location-trusted: true
+
+# SPA fallback serves index.html for any client-router path
+# (SvelteKit adapter-static + ServeDir fallback in
+# src/interfaces/web/mod.rs). Assert on URL, not on body — the
+# body is the SPA shell in every case.
+HTTP 200
+[Asserts]
+url matches "^http://localhost:8087/profile\\?link_error=email_mismatch$"
+
+
+# Post-refusal invariant: admin row unchanged, no federation
+# fields populated. This is the load-bearing safety proof —
+# a regression that mistakenly UPDATE-d the row before the
+# email check would trip here.
+GET {{base_url}}/api/auth/me
+
+HTTP 200
+[Asserts]
+jsonpath "$.federation_kind" not exists
+jsonpath "$.federation_issuer" not exists
+
+
+# ═════════════════════════════════════════════════════════════
+# Step 6 (Scenario 8) — already_linked_elsewhere refusal.
+# ═════════════════════════════════════════════════════════════
+# Flip the fake IdP to return admin's email so the email check
+# passes; the sub is STILL `oidc-test-user`, which oidc.hurl
+# already linked to `oidc_user`. The pre-UPDATE check in
+# complete_oidc_link (`get_user_by_federation_subject` → row
+# belongs to another user) fires and refuses with
+# `already_linked_elsewhere`.
+# ═════════════════════════════════════════════════════════════
+
+
+POST {{oidc_issuer}}/control/set-email
+Content-Type: application/json
+{ "email": "{{email}}" }
+
+HTTP 200
+[Asserts]
+jsonpath "$.overridden" == true
+jsonpath "$.email" == "{{email}}"
+
+
+POST {{base_url}}/api/auth/oidc/link/start
+Content-Type: application/json
+X-CSRF-Token: {{admin_csrf_token}}
+{}
+
+HTTP 200
+[Captures]
+taken_authorize_url: jsonpath "$.authorize_url"
+
+
+GET {{taken_authorize_url}}
+[Options]
+location: true
+location-trusted: true
+
+HTTP 200
+[Asserts]
+url matches "^http://localhost:8087/profile\\?link_error=already_linked_elsewhere$"
+
+
+GET {{base_url}}/api/auth/me
+
+HTTP 200
+[Asserts]
+jsonpath "$.federation_kind" not exists
+jsonpath "$.federation_issuer" not exists
+
+
+# ═════════════════════════════════════════════════════════════
+# Step 7 (Scenario 5) — Self-service link happy round-trip.
+# ═════════════════════════════════════════════════════════════
+# Swap the IdP to a FRESH sub (not-yet-linked to anyone) and
+# keep the admin email match from Step 6. The set-sub endpoint
+# also clears the OP's session cookies in the response so the
+# next authorize dance re-prompts login and binds to the new
+# sub. All five safety checks pass → link_federation_identity
+# UPDATE runs → callback returns LinkCompleted → 307 to
+# /profile?linked=1. /me now shows the federation identity.
+#
+# Then unlink admin (scenario 9 — success, has password) and
+# assert the federation fields clear.
+# ═════════════════════════════════════════════════════════════
+
+
+POST {{oidc_issuer}}/control/set-sub
+Content-Type: application/json
+{ "sub": "sub-link-happy" }
+
+HTTP 200
+[Asserts]
+jsonpath "$.overridden" == true
+jsonpath "$.sub" == "sub-link-happy"
+
+
+POST {{base_url}}/api/auth/oidc/link/start
+Content-Type: application/json
+X-CSRF-Token: {{admin_csrf_token}}
+{}
+
+HTTP 200
+[Captures]
+happy_authorize_url: jsonpath "$.authorize_url"
+
+
+GET {{happy_authorize_url}}
+[Options]
+location: true
+location-trusted: true
+
+HTTP 200
+[Asserts]
+url == "http://localhost:8087/profile?linked=1"
+
+
+# Federation now set on admin.
+GET {{base_url}}/api/auth/me
+
+HTTP 200
+[Asserts]
+jsonpath "$.username" == "{{username}}"
+jsonpath "$.federation_kind" == "oidc"
+jsonpath "$.federation_issuer" == "{{oidc_issuer}}"
+
+
+# Scenario 9 — unlink success (admin has a password, so the
+# no_alternative_auth guard doesn't fire).
+POST {{base_url}}/api/auth/oidc/unlink
+Content-Type: application/json
+X-CSRF-Token: {{admin_csrf_token}}
+{}
+
+HTTP 200
+
+
+GET {{base_url}}/api/auth/me
+
+HTTP 200
+[Asserts]
+jsonpath "$.federation_kind" not exists
+jsonpath "$.federation_issuer" not exists
+
+
+# ═════════════════════════════════════════════════════════════
+# Step 8 (Scenario 7) — +alias normalization link.
+# ═════════════════════════════════════════════════════════════
+# `common::text::normalize_email_for_link` strips +alias
+# sub-addressing (`admin+oidc@example.com` → `admin@example.com`)
+# and case-folds. Set the fake IdP to a FRESH sub and to the
+# +alias email; the link check normalizes both sides and finds
+# equivalence, so the link succeeds despite the raw strings
+# differing.
+# ═════════════════════════════════════════════════════════════
+
+
+POST {{oidc_issuer}}/control/set-sub
+Content-Type: application/json
+{ "sub": "sub-alias" }
+
+HTTP 200
+
+
+POST {{oidc_issuer}}/control/set-email
+Content-Type: application/json
+{ "email": "admin+oidc@example.com" }
+
+HTTP 200
+
+
+POST {{base_url}}/api/auth/oidc/link/start
+Content-Type: application/json
+X-CSRF-Token: {{admin_csrf_token}}
+{}
+
+HTTP 200
+[Captures]
+alias_authorize_url: jsonpath "$.authorize_url"
+
+
+GET {{alias_authorize_url}}
+[Options]
+location: true
+location-trusted: true
+
+HTTP 200
+[Asserts]
+url == "http://localhost:8087/profile?linked=1"
+
+
+GET {{base_url}}/api/auth/me
+
+HTTP 200
+[Asserts]
+jsonpath "$.federation_kind" == "oidc"
+
+
+# Unlink to reset state before the auto-link scenarios.
+POST {{base_url}}/api/auth/oidc/unlink
+Content-Type: application/json
+X-CSRF-Token: {{admin_csrf_token}}
+{}
+
+HTTP 200
+
+
+# ═════════════════════════════════════════════════════════════
+# Step 9 (Scenario 1) — Auto-link happy path.
+# ═════════════════════════════════════════════════════════════
+# This is the OIDC LOGIN callback path (not the self-service
+# link flow). The callback's (iss, sub) lookup MISSES on the
+# fresh sub, falls into the "match by email" branch, finds
+# admin (email match + email_verified=true + admin not already
+# linked), and auto-links. The flow proceeds like a regular
+# OIDC login: the callback yields WebLogin { exchange_code }
+# and 307s to /login?oidc_code=<code>. POST /exchange then
+# mints tokens for admin (not a JIT-provisioned new user).
+#
+# The admin session cookies from Step 1 are still in the jar;
+# /exchange returns fresh cookies that OVERWRITE the old ones
+# so subsequent requests use the auto-link-issued session.
+# ═════════════════════════════════════════════════════════════
+
+
+POST {{oidc_issuer}}/control/set-sub
+Content-Type: application/json
+{ "sub": "sub-auto-happy" }
+
+HTTP 200
+
+
+# Reset email to admin's (Step 8 left it at admin+oidc@example.com,
+# which would ALSO auto-link — but we assert on the strict-match
+# behavior here).
+POST {{oidc_issuer}}/control/set-email
+Content-Type: application/json
+{ "email": "{{email}}" }
+
+HTTP 200
+
+
+GET {{base_url}}/api/auth/oidc/authorize
+[Options]
+location: true
+location-trusted: true
+
+HTTP 200
+[Captures]
+autolink_oidc_code: url regex "oidc_code=([a-f0-9]+)"
+[Asserts]
+url matches "^http://localhost:8087/login\\?oidc_code=[a-f0-9]+$"
+
+
+POST {{base_url}}/api/auth/oidc/exchange
+Content-Type: application/json
+{ "code": "{{autolink_oidc_code}}" }
+
+HTTP 200
+[Asserts]
+# Auto-link resolved to the pre-existing admin, NOT a fresh
+# JIT-provisioned user. The load-bearing assertion.
+jsonpath "$.user.username" == "{{username}}"
+jsonpath "$.user.federation_kind" == "oidc"
+jsonpath "$.user.federation_issuer" == "{{oidc_issuer}}"
+[Captures]
+# Fresh cookies replace the password session's; capture the
+# new CSRF for the unlink below.
+autolink_csrf_token: cookie "oxicloud_csrf"
+
+
+# /me confirms admin session AND that the federation columns
+# are populated. Auto-link should have set kind=oidc, issuer=<fake>,
+# subject=sub-auto-happy on admin's row.
+GET {{base_url}}/api/auth/me
+
+HTTP 200
+[Asserts]
+jsonpath "$.username" == "{{username}}"
+jsonpath "$.federation_kind" == "oidc"
+jsonpath "$.federation_issuer" == "{{oidc_issuer}}"
+
+
+# Reset admin state before the next scenario (auto-link would
+# refuse if admin is already linked, so we'd never reach the
+# email_verified=false branch we want to test).
+POST {{base_url}}/api/auth/oidc/unlink
+Content-Type: application/json
+X-CSRF-Token: {{autolink_csrf_token}}
+{}
+
+HTTP 200
+
+
+# ═════════════════════════════════════════════════════════════
+# Step 10 (Scenario 2) — Auto-link refused, email_verified=false.
+# ═════════════════════════════════════════════════════════════
+# Same shape as scenario 1 but with the IdP asserting
+# email_verified=false. Auto-link gates on
+# `email_verified == Some(true)` regardless of the operator-level
+# OXICLOUD_REQUIRE_VERIFIED_EMAIL flag (auto-link uses the IdP
+# email as a takeover-mitigation signal — an unverified email
+# does not satisfy that), so the refusal path fires and the
+# callback returns `DomainError::AlreadyExists`.
+#
+# Wire behavior: HTTP 409 with error_type "Already Exists"
+# (ErrorKind::AlreadyExists → CONFLICT). The message is the
+# "contact admin to link your OIDC identity" text that surfaces
+# in the SPA login form's error toast.
+#
+# NOTE: `error_type` here is "Already Exists" (with a space)
+# because it comes from `ErrorKind::as_str()`, not from a
+# handler-set stable key. The auto-link refusal branch is
+# reusing the generic AlreadyExists mapping — a follow-up
+# could give it a dedicated `error_type` like
+# `AutoLinkEmailNotVerified` for the SPA to switch on.
+# ═════════════════════════════════════════════════════════════
+
+
+POST {{oidc_issuer}}/control/set-sub
+Content-Type: application/json
+{ "sub": "sub-verified-false" }
+
+HTTP 200
+
+
+POST {{oidc_issuer}}/control/email-verified/false
+
+HTTP 200
+
+
+# Follow the whole OIDC dance. Hurl's location: true follows 3xx
+# up to the callback; the callback returns 409 (non-3xx) and
+# location follow stops. The final response is what we assert on.
+GET {{base_url}}/api/auth/oidc/authorize
+[Options]
+location: true
+location-trusted: true
+
+HTTP 409
+[Asserts]
+jsonpath "$.error_type" == "Already Exists"
+
+
+# Belt-and-braces invariant: admin's row is still un-linked
+# (the refusal ran BEFORE link_federation_identity would fire).
+GET {{base_url}}/api/auth/me
+
+HTTP 200
+[Asserts]
+jsonpath "$.federation_kind" not exists
+
+
+# Reset fake IdP state (email_verified back to true, sub back
+# to TEST_USER_SUB) so the oidc_user re-login below resolves
+# correctly. The set-sub call ALSO clears the OP's session
+# cookies from the jar, ensuring the login prompt fires with
+# the reset sub bound instead of reusing the sub-verified-false
+# session.
+POST {{oidc_issuer}}/control/email-verified/true
+
+HTTP 200
+
+
+POST {{oidc_issuer}}/control/set-sub
+Content-Type: application/json
+{}
+
+HTTP 200
+[Asserts]
+jsonpath "$.overridden" == false
+
+
+POST {{oidc_issuer}}/control/set-email
+Content-Type: application/json
+{}
+
+HTTP 200
+
+
+# ═════════════════════════════════════════════════════════════
+# Step 11 (Scenario 10) — Unlink refused for the OIDC-only user.
+# ═════════════════════════════════════════════════════════════
+# Fresh OIDC login as `oidc_user` (the JIT-provisioned
+# federated principal from oidc.hurl). Uses the reset default
+# sub, so the (iss, sub) lookup HITS the existing oidc_user
+# row (linked in oidc.hurl Step 5) and the existing-user branch
+# runs — NOT auto-link.
+# ═════════════════════════════════════════════════════════════
+
+
 GET {{base_url}}/api/auth/oidc/authorize
 [Options]
 location: false
@@ -154,19 +600,17 @@ HTTP 200
 jsonpath "$.user.username" == "oidc_user"
 jsonpath "$.user.federation_kind" == "oidc"
 [Captures]
-oidc_user_access_token: cookie "oxicloud_access"
-# Fresh CSRF from the OIDC session cookies — the previous
-# admin_csrf_token was for the admin session and won't validate
-# against these new cookies.
+# Fresh CSRF from the OIDC session cookies — the admin CSRFs
+# won't validate against these new cookies.
 oidc_user_csrf_token: cookie "oxicloud_csrf"
 
 
-# ─────────────────────────────────────────────────────────────
-# Step 6 — oidc_user attempts to unlink. Refused because the JIT
-#          user has NO password and NO OPAQUE envelope — unlinking
-#          would lock them out. The backend guard fires with
-#          reason=no_alternative_auth → 403.
-# ─────────────────────────────────────────────────────────────
+# oidc_user has no password AND no OPAQUE envelope — unlinking
+# would lock them out entirely. The app service returns
+# DomainError::AccessDenied with reason=no_alternative_auth in
+# the audit log; the handler translates the generic AccessDenied
+# into a stable machine-readable `error_type` the SPA switches
+# on to render the "set a password first" affordance.
 POST {{base_url}}/api/auth/oidc/unlink
 Content-Type: application/json
 X-CSRF-Token: {{oidc_user_csrf_token}}
@@ -174,15 +618,10 @@ X-CSRF-Token: {{oidc_user_csrf_token}}
 
 HTTP 403
 [Asserts]
-# error_type is the stable machine-readable key the SPA switches
-# on to render the "set a password first" affordance.
 jsonpath "$.error_type" == "NoAlternativeAuth"
 
 
-# ─────────────────────────────────────────────────────────────
-# Step 7 — Verify unlink was refused: /me still shows the OIDC
-#          identity linked.
-# ─────────────────────────────────────────────────────────────
+# Post-refusal invariant: the OIDC identity is still linked.
 GET {{base_url}}/api/auth/me
 
 HTTP 200

--- a/tests/oidc/oidc.hurl
+++ b/tests/oidc/oidc.hurl
@@ -215,12 +215,15 @@ oidc_user_id: jsonpath "$.id"
 [Asserts]
 jsonpath "$.username" == "oidc_user"
 jsonpath "$.email"    == "oidc@example.com"
-# `auth_provider` stores the OIDC provider's display name (set via
-# OXICLOUD_OIDC_PROVIDER_NAME in tests/common/server-with-oidc.env),
-# NOT a generic "oidc" tag. A locally registered admin would have
-# this field as something like "local". The distinct value here is
-# what proves JIT provisioning landed via OIDC, not setup.hurl.
-jsonpath "$.auth_provider" == "MockSSO"
+# Post the federation-identity rename (docs/plan/ocm.md § Schema
+# rename) UserDto exposes federation_kind + federation_issuer as
+# separate nullable fields. Local users have both null; OIDC users
+# get kind="oidc" and issuer=<the id_token iss claim URL>. For
+# the fake IdP (tests/oidc/fake_idp/server.js) that URL is the
+# issuer published in its discovery document, which matches
+# `oidc_issuer` from test.env.
+jsonpath "$.federation_kind"   == "oidc"
+jsonpath "$.federation_issuer" == "{{oidc_issuer}}"
 # Full claim round-trip — the fake IdP (tests/oidc/fake_idp/server.js)
 # pins these values and OxiCloud must persist each one verbatim during
 # JIT provisioning (see auth_application_service.rs around line 2257).

--- a/tests/oidc/run.sh
+++ b/tests/oidc/run.sh
@@ -179,10 +179,13 @@ wait_for_http "$base_url/ready" 120
 log "Server is ready."
 
 # ── 5. Run the OIDC Hurl suite ─────────────────────────────────────────────
+# Order matters: oidc.hurl bootstraps the admin and JIT-provisions the
+# `oidc_user` federated principal that link_unlink.hurl then reuses.
 log "Running OIDC Hurl tests..."
 hurl --variables-file "$OIDC_DIR/test.env" \
      --file-root "$REPO_ROOT/tests" \
      --test --jobs 1 \
-     "$OIDC_DIR/oidc.hurl"
+     "$OIDC_DIR/oidc.hurl" \
+     "$OIDC_DIR/link_unlink.hurl"
 
 log "OIDC tests passed."

--- a/tools/perf-audit/admin_user_listing_e2e.rs
+++ b/tools/perf-audit/admin_user_listing_e2e.rs
@@ -73,7 +73,7 @@ struct FullUserDto {
     updated_at: DateTime<Utc>,
     last_login_at: Option<DateTime<Utc>>,
     active: bool,
-    auth_provider: String,
+    federation_issuer: String,
     image: Option<String>,
     can_edit_image: bool,
     is_external: bool,
@@ -100,7 +100,7 @@ impl FullUserDto {
             storage_used_bytes: self.storage_used_bytes,
             last_login_at: self.last_login_at,
             active: self.active,
-            auth_provider: self.auth_provider.clone(),
+            federation_issuer: self.federation_issuer.clone(),
             is_external: self.is_external,
         }
     }
@@ -117,7 +117,7 @@ struct SummaryUserDto {
     storage_used_bytes: i64,
     last_login_at: Option<DateTime<Utc>>,
     active: bool,
-    auth_provider: String,
+    federation_issuer: String,
     is_external: bool,
 }
 
@@ -270,7 +270,7 @@ async fn load_full(pool: &PgPool) -> Vec<FullUserDto> {
                 updated_at: row.get("updated_at"),
                 last_login_at: row.get("last_login_at"),
                 active: row.get("active"),
-                auth_provider: oidc_provider.unwrap_or_else(|| "local".to_owned()),
+                federation_issuer: oidc_provider.unwrap_or_else(|| "local".to_owned()),
                 image: row.get("image"),
                 can_edit_image,
                 is_external: row.get("is_external"),
@@ -312,7 +312,7 @@ async fn load_summary(pool: &PgPool) -> Vec<SummaryUserDto> {
         storage_used_bytes: row.get("storage_used_bytes"),
         last_login_at: row.get("last_login_at"),
         active: row.get("active"),
-        auth_provider: row
+        federation_issuer: row
             .get::<Option<String>, _>("oidc_provider")
             .unwrap_or_else(|| "local".to_owned()),
         is_external: row.get("is_external"),


### PR DESCRIPTION
Work in preparation for Open Cloud Mesh and for open federation

- bring issuer, permit admin to change oidc provider name without breaking the issuer name
- permit users to link or unlink there existing account to OIDC (only the OIDC defined by admin) 
- permit OIDC login to auto link an existing account
- improve login error handling
- support of +alias email (reconciliate the real email with the OIDC)

Bring plan to OCM and federated accounts

👌 hurl test ok
👌 tested manually