### PR TITLE
docs(plan): revise derived-blobs tier-2 design

### DIFF
--- a/docs/plan/derived-blobs.md
+++ b/docs/plan/derived-blobs.md
@@ -1,12 +1,13 @@
 # Plan — Derived content as blobs (tier-2 refactor)
 
-**Status:** design captured 2026-08-02, not implemented. Follow-up to
-`fix/services-use-blob-abstraction` — that PR normalised the
-**read-side** (services consume blobs through `BlobStorageBackend`
-uniformly). This plan tackles the **write-side**: services that
-today write derived artifacts (thumbnails, transcodes) to a local
-sidecar directory and would benefit from writing them through the
-backend abstraction instead.
+**Status:** design captured 2026-08-02, revised 2026-08-12 (keying,
+CDC reuse, backend-dispatch rule, client-preview boundary). Not
+implemented. Follow-up to `fix/services-use-blob-abstraction` — that
+PR normalised the **read-side** (services consume blobs through
+`BlobStorageBackend` uniformly). This plan tackles the **write-side**:
+services that today write derived artifacts (thumbnails, transcodes)
+to a local sidecar directory and would benefit from writing them
+through the backend abstraction instead.
 
 ## Context — the three-tier storage taxonomy
 
@@ -61,36 +62,244 @@ Reusing it for derived artifacts means no second abstraction to
 build and maintain, and all the operational surface (audit,
 migration, key rotation) applies to derived content by default.
 
-### Keying
+### Keying — content-address only pure functions of the content
 
-Content-addressable via BLAKE3, same as source blobs. For
-server-derived content the hash is over the produced bytes (not
-the source), so:
+**The rule:** an artifact may be keyed by its source's content hash
+**iff** it is a deterministic pure function of the source bytes.
+Anything influenced by user choice must be keyed by the resource it
+was attached to, never by content.
 
-- Two files with **identical thumbnails** (e.g. same 256px WebP
-  crop of the same underlying image → identical bytes → identical
-  hash) share the physical blob. Dedup wins for free.
-- Two files with **identical originals** but **different variant
-  specs** (256px vs 512px thumb) produce different blobs. Also
-  correct.
+| Artifact | Function of | Content-keyable? |
+|---|---|---|
+| server thumbnail | `f(blob bytes, variant)` | ✅ any user uploading identical bytes derives identical output — nothing to poison |
+| transcode | `f(blob bytes, target)` | ✅ |
+| extracted text | `f(blob bytes)` | ✅ — `storage.blob_extracted_text` |
+| face vectors | `f(blob bytes)` | ✅ — `faces.faces` |
+| client-uploaded preview | `f(user's choice)` | ❌ **must be file-keyed** — see below |
 
-The variant spec (what was rendered) lives in the referring DB row
-alongside the blob hash — not in the storage key. Storage stays
-one keyspace; ownership stays per-service.
+This isn't a new pattern: `storage.blob_extracted_text` already
+chose content-keying for the same reason, and the migration says so
+(`migrations/20260701000000_content_search_index.sql:22-28`) —
+"extraction is keyed by `blob_hash`, not by file: N copies of the
+same PDF cost ONE extraction, and rename/move/copy never
+re-extract." `faces.faces` is keyed on `blob_hash` too. Thumbnails
+are the same class of artifact, and file-keying them would make
+them the odd one out among three sibling features while costing:
 
-### Client-uploaded thumbnails
+- **the dedup fast path** — `ThumbnailRefreshHook::on_file_created`
+  returns early when `!is_new_blob`, so 100 users uploading the same
+  photo cost one render. File-keying means either N renders or a
+  join back through `file_metadata.blob_hash` (content-keying
+  through the back door, slower and with more code).
+- **free copies** — `on_file_copied` is a no-op today precisely
+  because the key is content.
+
+For the derived side the hash is over the **produced** bytes, so:
+
+- Two files with identical thumbnails (same variant of the same
+  source → identical bytes → identical hash) share the physical
+  blob. Dedup wins for free.
+- Two variants of one source (256px vs 512px) produce different
+  blobs. Also correct.
+
+The variant spec lives in the referring DB row, not in the storage
+key. Storage stays one keyspace; ownership stays per-service.
+
+### Schema
+
+```sql
+CREATE TABLE storage.derived_blobs (
+    source_hash VARCHAR(64) NOT NULL,   -- source Blob (no FK — see below)
+    kind        TEXT NOT NULL,          -- 'thumbnail' | 'transcode'
+    variant     TEXT NOT NULL,          -- 'icon.webp', 'large.jpg', 'av1.720p'
+    blob_hash   VARCHAR(64) NOT NULL,   -- the DERIVED Blob
+    size        BIGINT NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (source_hash, kind, variant)
+);
+CREATE INDEX ON storage.derived_blobs(blob_hash);
+```
+
+One table with a `kind` discriminator rather than separate
+`storage.thumbnails` / `storage.transcodes`: `count_references`,
+`list_referenced_blobs`, the GC cascade and the
+`backend_consistency` walk are byte-identical between the two, so
+two tables means maintaining a duplicate of that SQL — which
+`AGENTS.md § Code duplication` forbids. `kind` costs one column.
+
+**No FK on `source_hash` or `blob_hash`**, for the reason the
+search-index migration already documents: a file hash resolves to
+either `storage.blobs` (legacy whole blob) or
+`storage.chunk_manifests` (CDC file hash), so the reference can't be
+expressed as a single FK. Orphans are reclaimed by GC instead.
+
+**No `origin` column.** The 2026-08-02 draft had
+`origin = 'server_derived' | 'client_provided'` so consistency-check
+severity could differ. With client previews excluded from this table
+(below), every row is server-derived and the severity is uniformly
+"warning, regenerable" — the column carries no information. Re-add
+it only if that changes.
+
+**Deletion is app-layer, not `ON DELETE CASCADE`.** A SQL cascade
+would delete the mapping row without decrementing
+`storage.blobs.ref_count`, silently leaking a reference. So
+`on_blob_deleted(source_hash)` does
+`DELETE FROM storage.derived_blobs WHERE source_hash = $1 RETURNING blob_hash`
+then `remove_reference()` per row. That is a one-for-one replacement
+of today's `delete_blob_thumbnails` unlink loop — no new mechanism.
+
+### Write path — reuse `store_from_stream`, don't special-case CDC
+
+Derived blobs go through `DedupService::store_from_stream()`
+**unchanged**. An earlier draft of this plan proposed a dedicated
+single-chunk write path to avoid the manifest row; that was
+optimising the wrong thing. What it costs to reuse the standard
+path:
+
+- **+1 `chunk_manifests` row per derived blob.** `CDC_MIN_CHUNK` is
+  65_536, and WebP q82 thumbnails land at roughly 3–8 KB (icon),
+  15–30 KB (preview), 40–90 KB (large) — so icon and preview are
+  always below the minimum chunk size and emit exactly one chunk;
+  `large` occasionally splits into two.
+- **One manifest lookup per read**, served from RAM by
+  `manifest_cached` — not a per-read query.
+- **A CDC pass over ~12 KB** — below min-chunk, so a single pass
+  with no boundary search. Negligible.
+
+What it buys: zero new write path, zero new read path, and
+ref-counting, GC, `add_reference` / `remove_reference` and both
+consistency jobs all work on derived blobs with no changes, because
+they are already manifest-aware. One `store_from_stream` call == one
+reference == one `derived_blobs` row, symmetric on delete.
+
+Two gotchas that come with the reuse:
+
+1. `store_from_stream` fires `fire_blob_creation_hooks`. The only
+   non-dispatcher `BlobLifecycleHook` implementor today is
+   `ThumbnailService`, whose `on_blob_created` is a no-op — so no
+   spurious work now. But creating a thumbnail now fires
+   blob-creation hooks, so any future hook (search indexing, face
+   detection) must not treat every new blob as user content. Add a
+   `kind`/content-type guard to the hook contract before the second
+   implementor lands.
+2. GC of a *derived* blob fires `on_blob_deleted(derived_hash)`,
+   which looks for derived-of-derived rows, finds none and stops.
+   One level deep, terminates — but that's incidental rather than
+   designed. Comment it at the recursion point.
+
+### No backend-type branching in the service
+
+`src/AGENTS.md` already forbids the shape this refactor must avoid:
+
+> - **Never hand-craft blob paths.** No `blob_root: PathBuf` fields […]
+> - **Persistent state = backend**, not `<storage_path>/*` sidecars.
+
+`thumbnail_service` is cited there as a read-side reference impl,
+and the read side is compliant. The write side is the violation:
+`thumbnails_root: PathBuf` is exactly the banned field, and
+`get_thumbnail_path()` is the hand-crafted path.
+
+There must be **no `if backend is local { .thumbnails/… } else { blob }`
+anywhere in the service.** `ThumbnailService` holds
+`Arc<DedupService>`, reads and writes through it, and never learns
+which backend it is sitting on. The local-vs-remote difference is
+expressed once, as decorator composition in `common/di.rs`:
+
+```rust
+if self.config.storage.cache.enabled && active_backend_kind != StorageBackendType::Local {
+    blob_backend = Arc::new(CachedBlobBackend::new(blob_backend, &cfg));
+}
+```
+
+Local deployments write derived blobs into `<storage>/.blobs/` via
+`LocalBlobBackend` with no cache decorator (a cache would be a
+byte-identical second copy on the same disk). Remote deployments get
+the cache. Same service code both ways — and it is the same branch
+that already governs source blobs, not a new one.
+
+What this deletes from `thumbnail_service.rs`:
+
+- `thumbnails_root` field, `get_thumbnail_path()`,
+  `ThumbnailSize::dir_name()` (becomes `variant()`, feeding the DB
+  column)
+- `initialize()`'s `create_dir_all` loop
+- every `fs::read` / `fs::write` / `fs::metadata` / `remove_file`
+- the three `all_exist` stat loops → one indexed query each
+- `delete_blob_thumbnails`'s unlink loop and the duplicate of it
+  inside `on_blob_deleted`
+
+Net deletion, which is the main argument for this shape.
+
+Two adjacent cleanups in the same file: `stream_blob_to_temp` uses
+`self.thumbnails_root` as its temp directory and must move to
+`AppConfig::temp_dir` per the `OXICLOUD_TEMP_DIR` rule; and
+`store_external_thumbnail`'s `ext-{file_id}.jpg` write is the last
+hand-crafted path once the rest is converted.
+
+### Client-uploaded thumbnails — file-keyed, and NOT in `derived_blobs`
 
 Some clients (NC desktop, mobile apps) upload their own encoded
 previews alongside the file. These are **not derivable** — losing
 them means asking the client to regenerate, which may not be
-possible (client offline, original file no longer present on
-device).
+possible.
 
-Same storage shape: BLAKE3 of the client-provided bytes → blob.
-The DB row distinguishes `origin = 'server_derived' | 'client_provided'`
-so consistency-check policy can differ (missing client-provided
-thumbnail = data loss finding; missing server-derived = warning,
-regenerable).
+They are also **not a function of the content**, and that makes
+content-keying a cross-user poisoning vector:
+
+1. User A uploads file X plus a preview that does not depict X.
+   There is no validation that can catch this — verifying a preview
+   faithfully represents its source means re-deriving and comparing,
+   at which point accepting the client's upload is pointless.
+2. User B uploads the same file X. Dedup matches on `source_hash`.
+3. B is served A's preview.
+
+So client previews **stay file-keyed and stay out of
+`storage.derived_blobs`.** This is a precondition for the table
+having no `source_file_id` column, not an independent choice — the
+two decisions must land together.
+
+Today's code is already safe, implicitly, via its choice of
+filename; the risk is losing that in the migration:
+
+- write is file-keyed — `store_external_thumbnail` writes only
+  `ext-{file_id}.jpg`, never into the `{blob_hash}.{ext}` space
+- read checks the file-keyed path *before* the content-keyed one in
+  `get_cached_thumbnail`, so a preview only surfaces for its own
+  file
+- `PUT …/thumbnail/{size}` requires `Permission::Update` on the
+  target file
+
+Two things keep the boundary after the refactor:
+
+- **The schema is self-guarding.** With no `source_file_id` column
+  there is nowhere to put a client preview, so making the mistake
+  requires writing a migration — which gets reviewed. Keeping a
+  nullable column would be an attractive nuisance; omitting it *is*
+  the enforcement.
+- **State the invariant in the migration**, in the style
+  `content_search_index.sql` already uses: *keyed by `source_hash`
+  because derived content is a pure function of the source bytes;
+  client-uploaded previews are NOT derived, are user-chosen, and
+  must never be keyed here or one user's preview would be served for
+  another user's identical file.*
+
+Note the pressure this is under: a "unify the two write paths" pass
+would produce exactly the vulnerability. The two axes are separate —
+client previews share the **dispatch** (they become blobs via
+`store_from_stream` like everything else, satisfying the
+no-backend-branching rule) while keeping **file keying** in their own
+small mapping table. Storage dedup is preserved either way, because
+the derived bytes are still content-addressed: two byte-identical
+previews converge on one object at `ref_count = 2`. Only the mapping
+is per-file, and the mapping is the part that carries the trust
+problem.
+
+Current scope note: the SvelteKit frontend has no caller of the
+thumbnail `PUT` endpoint outside a test file — server-side ffmpeg
+extraction (`generate_video_thumbnails_background`) replaced it. So
+the client-preview table is speculative; don't build it until
+there's a real feature ask, and don't pay dual-key complexity for it
+in the meantime.
 
 ## `BlobReferenceSource` — reference tracking abstraction
 
@@ -105,7 +314,7 @@ The extension point:
 pub trait BlobReferenceSource: Send + Sync {
     /// Short stable identifier for logs / consistency finding
     /// `source` fields. Suggested: `"files"`, `"chunks"`,
-    /// `"thumbnails"`, `"transcodes"`.
+    /// `"derived"`.
     fn source_name(&self) -> &'static str;
 
     /// Count of references this source holds on `blob_hash`.
@@ -151,17 +360,20 @@ registrations:
 - `FilesReferenceSource` — wraps `storage.files.blob_hash`
 - `ChunksReferenceSource` — wraps `storage.chunk_manifests.chunk_hashes[]`
 
-Tier-2 migration adds:
+Tier-2 migration adds exactly **one** more (not one per kind, since
+`derived_blobs` is one table):
 
-- `ThumbnailsReferenceSource` — wraps a new
-  `storage.thumbnails(hash, blob_hash, variant_spec, origin)` table
-- `TranscodesReferenceSource` — wraps
-  `storage.transcodes(hash, blob_hash, target_format)` table
+- `DerivedBlobsReferenceSource` — wraps `storage.derived_blobs`;
+  `count_references` is
+  `SELECT count(*) FROM storage.derived_blobs WHERE blob_hash = $1`
 
 Then:
 
 - **`dedup_gc`** — orphan iff `registry.total_references(hash) == 0`
-  (with the existing grace window). No per-service GC changes.
+  (with the existing grace window). No per-service GC changes, and
+  none needed for derived blobs either: they carry real `ref_count`
+  in `storage.blobs`, so the existing grace-window sweep is already
+  correct.
 - **`blobs_consistency`** — `refcount_mismatch` recomputes via
   `registry.total_references`. New services register → automatically
   covered.
@@ -169,24 +381,115 @@ Then:
   `list_referenced_blobs` streams for the "did we lose bytes"
   check.
 
+**Hard ordering dependency.** `blobs_consistency` derives expected
+refcounts from `file_metadata` + manifests only. Ship
+`storage.derived_blobs` before the registry and *every* derived blob
+becomes a `refcount_mismatch` finding — a flood, and one an operator
+might "repair". Step 1 must precede step 3 below; this is not a
+sequencing preference.
+
+## Read path and caching
+
+Request carries `(file_id, size, format)`; the derived hash is
+BLAKE3 of bytes that don't exist yet, so it is not computable from
+the request. Read order:
+
+1. **moka RAM tier** — keyed by `(source_hash, size, format)`.
+   (Today it is keyed by `file_id`; rekeying to `source_hash` costs
+   nothing — the handler already has the hash from the row it
+   loaded — and stops N copies of one photo occupying N entries for
+   identical bytes.)
+2. **DB** — `derived_blobs` lookup for the variant. This is free:
+   the miss path already queries `get_blob_hash(&id)`, so a
+   `LEFT JOIN` on `derived_blobs` returns the source hash and the
+   derived hash in one query. Net DB cost unchanged from today.
+3. **`dedup.read_blob_bytes(derived_hash)`** — through the normal
+   backend stack, which is where the disk cache lives.
+4. Generate only if step 2 found no row.
+
+**The disk cache is `CachedBlobBackend`, reused unchanged.** No
+thumbnail-specific cache, no second root path. Routing derived
+blobs through the same stack gets, for free:
+
+- **single-flight per hash** — a gallery cold-load where 50 clients
+  race one thumbnail collapses to one S3 GET
+- **write-through on put** — the instance that generated the
+  thumbnail already has it locally, so upload→view-gallery never
+  round-trips to S3
+- byte-budget eviction with unlink, and a restart-survivable index
+
+**One thing to test rather than assume.** Thumbnails and source
+blobs have opposite cache profiles: small / hot / expensive to
+regenerate versus large / cold / cheap to re-fetch. Sharing one LRU
+budget (`OXICLOUD_STORAGE_CACHE_MAX_SIZE`, default 50 GB) means a
+sequential multi-GB video read is exactly the scan pattern that
+flushes a working set — and flushing thumbnails costs a re-render,
+not a re-download. moka 0.12's TinyLFU admission *should* resist
+this (a one-shot large entry denied rather than evicting
+frequently-hit small ones), and the eviction listener unlinks on
+`RemovalCause::Size` so a denied entry shouldn't leak its file. Both
+deserve a test, because the failure mode is silent: unexplained CPU
+on the thumbnail path, not a cache metric.
+
+If it does interfere, the fix that preserves the one-implementation
+rule is **two instances of `CachedBlobBackend` with separate
+budgets** — same type, same factory, different config — not a second
+cache type. Honest cost: `DedupService` would need a second backend
+handle plus a content-class selector, since derived blobs have
+manifests and must still be reassembled through `DedupService`. Ship
+the shared cache, measure, split only if the test says so. The knob
+would be `OXICLOUD_STORAGE_DERIVED_CACHE_MAX_SIZE` alongside the
+existing `OXICLOUD_STORAGE_CACHE_MAX_SIZE`.
+
+## Cost consequences to budget for
+
+1M photos × 3 sizes ≈ **3M additional backend objects and 3M
+additional `storage.blobs` + `chunk_manifests` rows** (~100 KB of
+derived content per photo, so ~100 GB total). Two costs land:
+
+- **PUT requests at upload** — one-off, modest (~$15 per 3M on AWS
+  pricing). Use `put_blob_from_bytes_unsynced` + a batched
+  `sync_blobs`, not `put_blob_from_bytes`: the latter does a
+  `head_object` before every PUT on S3, doubling the request count
+  for an idempotency check content-addressing already guarantees.
+- **`blobs_consistency` request amplification** — it does one
+  `blob_exists` HEAD per blob row, so 4× the rows is 4× the S3
+  requests, forever. This is the dominant recurring cost. Fix by
+  diffing against `list_blob_hashes` pages in bulk (one LIST per
+  1000 keys instead of 1000 HEADs) rather than per-row probes.
+  Alternative: exempt derived rows from the byte-level check, since
+  they are regenerable — but the bulk-LIST fix is better and helps
+  source blobs too.
+
+Note for object-store deployments: IA/Glacier tiers bill a 128 KB
+minimum per object, so an 8 KB icon is billed at 128 KB. **Open
+option** (config, not a code branch): persist only the `large`
+variant to tier 3 and derive icon/preview from it on demand — the
+render path already decodes once for all sizes, and resampling an
+800px WebP is sub-millisecond. That is 1M objects instead of 3M. It
+changes only *how many variants get a `derived_blobs` row*, so it
+stays a single code path.
+
 ## Sidecar directories after this refactor
 
 | Sidecar today | After |
 |---|---|
-| `.thumbnails/` | Persisted as derived blobs in tier 3. `.thumbnails/` becomes a pure read-through cache (tier 1-ish; ephemeral, per-instance). |
-| `.transcoded/` | Same shape as thumbnails. |
-| `.blob-cache/` | Already a cache; stays. Owned by `CachedBlobBackend`. |
+| `.thumbnails/` | **Gone.** Derived blobs live in tier 3; caching is `CachedBlobBackend` in `.blob-cache/`, keyed by hash like every other blob. |
+| `.transcoded/` | Gone, same shape. |
+| `.blob-cache/` | Stays. Owned by `CachedBlobBackend`, path via `OXICLOUD_STORAGE_CACHE_PATH`. Now serves derived blobs too. |
 | `.search-index/` | Open question — see non-goals. |
 | `.plugin-logs/` | Ops-local; stays. |
 | `.uploads/` | Tier 1 already; migrates to `OXICLOUD_TEMP_DIR`. |
 
-The persistent-spool env var reserved:
-
-- **`OXICLOUD_SPOOL_DIR`** — path for the local read-through
-  caches (`.thumbnails/`, `.transcoded/`, `.blob-cache/`). Default
-  `<storage_path>/spool`. Ops can point it at a different disk
-  than tier-3 storage; multi-instance deployments accept per-
-  instance rebuild OR mount a shared FS here.
+**`OXICLOUD_SPOOL_DIR` is probably no longer worth adding.** The
+2026-08-02 draft reserved it as the home for `.thumbnails/`,
+`.transcoded/` and `.blob-cache/`. The first two now disappear
+entirely rather than becoming local caches, and `.blob-cache/`
+already has its own `OXICLOUD_STORAGE_CACHE_PATH`. That leaves
+`.search-index/` (a non-goal) and `.plugin-logs/` (ops-local) — not
+enough to justify a new config surface. Either drop step 2 below or
+reduce it to documenting the existing `OXICLOUD_STORAGE_CACHE_PATH`
+as the tier-2 relocation knob.
 
 ## Delivery order
 
@@ -199,16 +502,21 @@ hardcoded SQL). New sources bolt on independently.
    `ChunksReferenceSource` implementations mirroring current SQL;
    wire into `dedup_gc` + `blobs_consistency` behind an integration
    test that proves the union equals the pre-refactor count on a
-   real DB.
-2. **`OXICLOUD_SPOOL_DIR`** — config + `example.env` + docs +
-   `AppConfig::spool_dir`. Migrate `CachedBlobBackend` cache path
-   default to `<spool_dir>/blob-cache/`.
-3. **`ThumbnailService` writes go through the backend**. New
-   `storage.thumbnails` table + `ThumbnailsReferenceSource`. Local
-   `.thumbnails/` sidecar becomes a read-through cache pattern.
-4. **`ImageTranscodeService`** — same shape as thumbnails.
-5. **Client-uploaded thumbnails** — new `origin` column + upload
-   API path if needed.
+   real DB. **Blocks step 3** (see the ordering dependency above).
+2. ~~`OXICLOUD_SPOOL_DIR`~~ — reduced to a docs change, or dropped;
+   see the sidecar section.
+3. **`ThumbnailService` writes go through `DedupService`**. New
+   `storage.derived_blobs` table + `DerivedBlobsReferenceSource`.
+   Deletes `thumbnails_root`, `get_thumbnail_path`, and every
+   filesystem call in the service. Fold the `derived_blobs` lookup
+   into the handler's existing `get_blob_hash` query.
+4. **`blobs_consistency` bulk-LIST diff** — before, or immediately
+   after, step 3 lands at scale; per-row HEADs do not survive a 4×
+   row count.
+5. **`ImageTranscodeService`** — same shape, `kind = 'transcode'`,
+   no new table.
+6. **Client-uploaded previews** — only if a real feature ask
+   appears. Separate file-keyed table; never in `derived_blobs`.
 
 Each slice is independently mergeable. Delivery span: rough
 estimate ~2 weeks end-to-end.
@@ -291,6 +599,10 @@ lands so we don't stack schema changes.
 - **Client thumbnail negotiation protocol** — the wire-level API
   for how clients push their previews. Design piece for the
   photo/mobile team when there's a real feature ask.
+- **A per-derived-content cache type.** Explicitly rejected: the
+  disk cache is `CachedBlobBackend`, instantiated by the existing
+  DI branch. Splitting budgets means a second *instance*, never a
+  second implementation.
 
 ## References
 
@@ -301,6 +613,10 @@ lands so we don't stack schema changes.
 - `docs/plan/storage-key-rotation.md` — encryption/rotation applies
   to derived blobs too.
 - `src/AGENTS.md` — the read-side rule enforcing backend
-  abstraction (already shipped alongside this plan doc).
+  abstraction, the no-hand-crafted-paths rule, and the
+  persistent-state-is-backend rule this plan implements.
+- `migrations/20260701000000_content_search_index.sql` — the
+  content-keying precedent (`storage.blob_extracted_text`) and its
+  rationale.
 - Memory note `project_services_bypassing_blob_backend` — audit
   history of the pre-normalisation bypasses.


### PR DESCRIPTION
Revises `docs/plan/derived-blobs.md` after a design pass over the current thumbnail/blob code. **Docs only — no code or schema changes.**

## Substantive changes

**Keying.** States the rule — content-address only artifacts that are a pure deterministic function of the source bytes — and cites the existing precedent: `storage.blob_extracted_text` (`content_search_index.sql:22-28`) and `faces.faces` already key derived artifacts by `blob_hash` for exactly this reason. File-keying thumbnails would cost the `!is_new_blob` dedup fast path and make `on_file_copied` non-free.

**Schema.** Concrete `storage.derived_blobs` with `PRIMARY KEY (source_hash, kind, variant)`. One table with a `kind` discriminator rather than separate `thumbnails`/`transcodes` tables, since their ref-source and consistency SQL would be byte-identical. No FK (a file hash resolves to either `storage.blobs` or `chunk_manifests`), no `origin`, no `source_file_id`. Deletion stays app-layer because a SQL `ON DELETE CASCADE` would drop the mapping row without decrementing `storage.blobs.ref_count`.

**Write path.** Reuse `DedupService::store_from_stream` unchanged instead of adding a single-chunk path for small derived blobs. Thumbnails fall below `CDC_MIN_CHUNK` (64 KB) so they emit one chunk anyway; the cost is one manifest row per derived blob and the payoff is that refcounting, GC, `add_reference`/`remove_reference` and both consistency jobs need no changes.

**No backend-type branching.** New section recording that the service must never ask which backend it is on — no `if local { .thumbnails/… } else { blob }`. Names the `src/AGENTS.md` rules the write side currently violates (`thumbnails_root: PathBuf`, `get_thumbnail_path()`), locates the one legitimate branch in `di.rs` decorator composition, and lists what the refactor deletes.

**Client-uploaded previews.** These are not a function of the content, so content-keying them means user A can upload a preview unrelated to its source and have it served to user B who uploads the same file — with no validation possible, since verifying a preview means re-deriving it. They stay file-keyed and out of `derived_blobs`; this is a *precondition* for omitting `source_file_id`, not an independent choice. Notes that today's code is already safe (file-keyed write, file-keyed read checked first, `Permission::Update` on the PUT) and that the schema having nowhere to put them is the enforcement.

**Read path / caching.** The disk cache is `CachedBlobBackend` reused unchanged — no thumbnail-specific cache. Flags the shared-LRU interaction between small-hot thumbnails and large-cold source blobs as something to test rather than assume, with two *instances* (not a second cache type) as the escape hatch.

## Housekeeping

- Drops `OXICLOUD_SPOOL_DIR` from the delivery order — its two main tenants disappear rather than becoming local caches, and `.blob-cache/` already has `OXICLOUD_STORAGE_CACHE_PATH`.
- Records the hard ordering dependency: the ref registry must precede the table, or `blobs_consistency` flags every derived blob as `refcount_mismatch`.
- Adds the `blobs_consistency` per-row-HEAD amplification (4× rows = 4× S3 requests, forever) as its own delivery slice, with a bulk-`list_blob_hashes` diff as the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)