### PR TITLE
Bump version to 0.8.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "oxicloud"
-version = "0.8.7"
+version = "0.8.9"
 dependencies = [
  "accept-language",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxicloud"
-version = "0.8.7"
+version = "0.8.9"
 edition = "2024"
 default-run = "oxicloud"
 


### PR DESCRIPTION
## Description

Bump version in Cargo.toml to 0.8.9, this shows the correct version in the "about" panel.

## Related Issue

https://github.com/AtalayaLabs/OxiCloud/issues/632

## Type of Change

Please check the option that best describes your change:

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?

Ran OxiCloud, verified about panel now shows version 0.8.9.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules