### PR TITLE
fix(mounts): scope external mounts to drives

### DIFF
--- a/docs/external-mounts.md
+++ b/docs/external-mounts.md
@@ -1,0 +1,23 @@
+# External mounts
+
+External mounts expose files from a provider such as a host directory inside an
+OxiCloud drive. Enable the feature with `OXICLOUD_ENABLE_EXTERNAL_MOUNTS=true`,
+then configure mounts from **Administration > External Mounts**.
+
+Each mount must be attached to a drive. The mount-root is a normal folder in
+that drive, and access to all provider content is inherited from the drive's
+membership and roles:
+
+- a mount in a personal drive is visible only to that drive's owner;
+- a mount in a shared drive is visible to members who can read the drive;
+- mutations additionally require the corresponding drive permission and are
+  always rejected when the mount is configured as read-only.
+
+Removing a mount deletes only its OxiCloud mount-root and configuration. It does
+not delete the provider's root directory. Deleting files or folders *inside* a
+writable mount is permanent because external mounts do not use OxiCloud trash.
+
+Mounts created before drive selection was introduced remain attached to their
+existing drive, normally the configuring administrator's personal drive. To
+make one available through a shared drive, remove it and recreate it with that
+shared drive selected; removing the old mount does not remove host content.

--- a/frontend/src/lib/api/endpoints/admin.ts
+++ b/frontend/src/lib/api/endpoints/admin.ts
@@ -793,6 +793,7 @@ export interface ExternalMount {
 export interface CreateExternalMountInput {
 	name: string;
 	host_path: string;
+	drive_id: string;
 	kind?: string;
 	read_only?: boolean;
 }
@@ -804,7 +805,7 @@ export function listExternalMounts(): Promise<ExternalMount[]> {
 	});
 }
 
-/** POST /api/admin/external-mounts — create a mount in the admin's drive. */
+/** POST /api/admin/external-mounts — create a mount in the selected drive. */
 export async function createExternalMount(input: CreateExternalMountInput): Promise<ExternalMount> {
 	const res = await apiFetch('/api/admin/external-mounts', {
 		method: 'POST',

--- a/frontend/src/routes/admin/[[tab]]/+page.svelte
+++ b/frontend/src/routes/admin/[[tab]]/+page.svelte
@@ -253,26 +253,41 @@
 
 	// External mounts
 	let mounts = $state<ExternalMount[] | null>(null);
+	let mountDrives = $state<Drive[]>([]);
 	let mountsError = $state<string | null>(null);
-	let newMount = $state<CreateExternalMountInput>({ name: '', host_path: '', read_only: false });
+	let newMount = $state<CreateExternalMountInput>({
+		name: '',
+		host_path: '',
+		drive_id: '',
+		read_only: false
+	});
 	let mountCreating = $state(false);
 
 	async function loadMounts() {
 		mountsError = null;
 		try {
-			mounts = await listExternalMounts();
+			[mounts, mountDrives] = await Promise.all([listExternalMounts(), listAllDrives()]);
 		} catch (e) {
 			mountsError = errorMessage(e);
 		}
 	}
 
+	function mountDriveName(driveId: string): string {
+		return mountDrives.find((drive) => drive.id === driveId)?.name ?? driveId;
+	}
+
 	async function createMount() {
-		if (!newMount.name.trim() || !newMount.host_path.trim()) return;
+		if (!newMount.name.trim() || !newMount.host_path.trim() || !newMount.drive_id) return;
 		mountCreating = true;
 		try {
 			const created = await createExternalMount(newMount);
 			mounts = [...(mounts ?? []), created];
-			newMount = { name: '', host_path: '', read_only: false };
+			newMount = {
+				name: '',
+				host_path: '',
+				drive_id: newMount.drive_id,
+				read_only: false
+			};
 		} catch (e) {
 			mountsError = errorMessage(e);
 		} finally {
@@ -3267,11 +3282,21 @@
 					bind:value={newMount.host_path}
 					data-testid="mount-path"
 				/>
+				<select bind:value={newMount.drive_id} required data-testid="mount-drive">
+					<option value="" disabled>{t('admin.mounts.drive_select', 'Select a drive')}</option>
+					{#each mountDrives as drive (drive.id)}
+						<option value={drive.id}>{drive.name}</option>
+					{/each}
+				</select>
 				<label>
 					<input type="checkbox" bind:checked={newMount.read_only} />
 					{t('admin.mounts.readonly', 'Read-only')}
 				</label>
-				<button type="submit" disabled={mountCreating} data-testid="mount-create">
+				<button
+					type="submit"
+					disabled={mountCreating || !newMount.drive_id}
+					data-testid="mount-create"
+				>
 					{t('admin.mounts.add', 'Add mount')}
 				</button>
 			</form>
@@ -3289,6 +3314,7 @@
 							<tr>
 								<th>{t('admin.mounts.name', 'Name')}</th>
 								<th>{t('admin.mounts.kind', 'Kind')}</th>
+								<th>{t('admin.mounts.drive', 'Drive')}</th>
 								<th>{t('admin.mounts.path', 'Path')}</th>
 								<th>{t('admin.mounts.readonly', 'Read-only')}</th>
 								<th></th>
@@ -3299,6 +3325,7 @@
 								<tr>
 									<td>{m.name}</td>
 									<td>{m.kind}</td>
+									<td>{mountDriveName(m.drive_id)}</td>
 									<td class="muted">{m.mount_path}</td>
 									<td>{m.read_only ? t('common.yes', 'Yes') : t('common.no', 'No')}</td>
 									<td>

--- a/frontend/src/routes/admin/[[tab]]/page.test.ts
+++ b/frontend/src/routes/admin/[[tab]]/page.test.ts
@@ -50,6 +50,7 @@ vi.mock('$lib/api/endpoints/admin', () => ({
 	deleteUser: vi.fn(),
 	getDashboard: vi.fn(),
 	listExternalMounts: vi.fn(),
+	listAllDrives: vi.fn(),
 	getMigration: vi.fn(),
 	getOidcSettings: vi.fn(),
 	getPluginLogs: vi.fn(),
@@ -129,6 +130,17 @@ const mount = {
 	config: { path: '/srv/media', read_only: true }
 };
 
+const mountDrive = {
+	id: 'd1',
+	name: 'Shared media',
+	kind: 'shared',
+	root_folder_id: 'root-d1',
+	used_bytes: 0,
+	policies: {},
+	created_at: '2026-09-01T00:00:00Z',
+	updated_at: '2026-09-01T00:00:00Z'
+};
+
 beforeEach(() => {
 	vi.clearAllMocks();
 	// Reset the tab mock so a test that sets `setTab('users')`
@@ -167,6 +179,7 @@ beforeEach(() => {
 		user_state: 'unset'
 	});
 	m(admin.listExternalMounts).mockResolvedValue([mount]);
+	m(admin.listAllDrives).mockResolvedValue([mountDrive]);
 });
 
 it('loads the dashboard on mount', async () => {
@@ -227,8 +240,10 @@ it('loads external mounts when the mounts tab is opened and lists them', async (
 	setTab('mounts');
 	render(AdminPage);
 	await waitFor(() => expect(admin.listExternalMounts).toHaveBeenCalled());
+	await waitFor(() => expect(admin.listAllDrives).toHaveBeenCalled());
 	// The configured mount is rendered in the table.
 	expect(await screen.findByText('Media')).toBeTruthy();
+	expect((await screen.findAllByText('Shared media')).length).toBeGreaterThan(0);
 });
 
 it('creates a mount from the mounts form', async () => {
@@ -250,10 +265,13 @@ it('creates a mount from the mounts form', async () => {
 	await fireEvent.input(screen.getByTestId('mount-path'), {
 		target: { value: '/srv/photos' }
 	});
+	await fireEvent.change(screen.getByTestId('mount-drive'), {
+		target: { value: 'd1' }
+	});
 	await fireEvent.click(screen.getByTestId('mount-create'));
 	await waitFor(() =>
 		expect(admin.createExternalMount).toHaveBeenCalledWith(
-			expect.objectContaining({ name: 'Photos', host_path: '/srv/photos' })
+			expect.objectContaining({ name: 'Photos', host_path: '/srv/photos', drive_id: 'd1' })
 		)
 	);
 });

--- a/migrations/20261025000000_external_mount_drive_visibility.sql
+++ b/migrations/20261025000000_external_mount_drive_visibility.sql
@@ -1,0 +1,12 @@
+-- External mounts inherit access from the drive containing their mount-root
+-- folder. Existing mounts remain in their current drive; for the historical
+-- default that is the configuring administrator's personal drive.
+UPDATE storage.external_mounts
+SET visibility = 'drive'
+WHERE visibility = 'owner';
+
+ALTER TABLE storage.external_mounts
+    ALTER COLUMN visibility SET DEFAULT 'drive';
+
+COMMENT ON COLUMN storage.external_mounts.visibility IS
+    'Compatibility marker. External mount visibility is inherited from the mount-root folder drive and its role grants.';

--- a/src/application/services/folder_service.rs
+++ b/src/application/services/folder_service.rs
@@ -1783,12 +1783,18 @@ mod mount_authz_integration {
     use crate::application::services::external_mount_router::{MountRouter, ResolvedId};
     use crate::application::services::file_retrieval_service::FileRetrievalService;
     use crate::application::services::mount_registry::MountRegistry;
+    use crate::domain::repositories::drive_repository::DriveRepository;
+    use crate::domain::repositories::folder_repository::FolderRepository;
+    use crate::domain::services::authorization::Subject;
     use crate::domain::services::external_mount_id::{NodeId, encode_child_id};
     use crate::infrastructure::repositories::pg::{
-        ExternalMountPgRepository, FileBlobReadRepository, SubjectGroupPgRepository,
+        DrivePgRepository, ExternalMountPgRepository, FileBlobReadRepository,
+        SubjectGroupPgRepository,
     };
     use crate::infrastructure::services::mount_provider_factory::DefaultMountProviderFactory;
-    use crate::mount_it_support::{fresh_db, insert_mount, make_user, provision_folder};
+    use crate::mount_it_support::{
+        Provisioned, fresh_db, insert_mount, make_user, provision_folder,
+    };
     use std::sync::Arc;
 
     fn opts<'a>() -> ListResourcesOptions<'a> {
@@ -2203,6 +2209,68 @@ mod mount_authz_integration {
             .list_mount_dir_with_perms(&cfg, &NodeId::default(), stranger, opts())
             .await
             .expect_err("stranger must be denied");
+        assert_eq!(err.kind, crate::domain::errors::ErrorKind::NotFound);
+    }
+
+    /// A mount attached to a shared drive inherits that drive's grants rather
+    /// than the identity of the administrator who configured the provider.
+    #[tokio::test]
+    async fn shared_drive_member_lists_mount_non_member_denied() {
+        let (_c, pool) = fresh_db().await;
+        let host = tempfile::tempdir().unwrap();
+        std::fs::write(host.path().join("shared.txt"), b"shared").unwrap();
+
+        let admin_id = make_user(&pool, "mount-admin").await;
+        let member_id = make_user(&pool, "drive-member").await;
+        let drive = DrivePgRepository::new(pool.clone())
+            .create_shared_drive_atomic("Shared media", Subject::User(member_id), None, admin_id)
+            .await
+            .expect("create shared drive");
+        let folder = FolderDbRepository::new(pool.clone())
+            .create_folder(
+                "Media".to_string(),
+                Some(drive.drive.root_folder_id.to_string()),
+                admin_id,
+            )
+            .await
+            .expect("create mount root in shared drive");
+        let mount_folder_id = Uuid::parse_str(folder.id()).expect("folder UUID");
+        let provisioned = Provisioned {
+            owner_id: admin_id,
+            drive_id: drive.drive.id,
+            mount_folder_id,
+        };
+        insert_mount(&pool, &provisioned, host.path().to_str().unwrap()).await;
+
+        let registry = Arc::new(MountRegistry::empty());
+        registry
+            .reload(
+                &ExternalMountPgRepository::new(pool.clone()),
+                &DefaultMountProviderFactory::new(),
+            )
+            .await;
+        let folder_service = FolderService::new(
+            Arc::new(FolderDbRepository::new(pool.clone())),
+            acl(&pool),
+            Arc::new(
+                crate::application::services::file_lifecycle_service::FileLifecycleService::new(),
+            ),
+            Arc::new(MountRouter::new(registry.clone())),
+        );
+        let cfg = registry.get(&mount_folder_id).expect("mount registered");
+
+        let (entries, _) = folder_service
+            .list_mount_dir_with_perms(&cfg, &NodeId::default(), member_id, opts())
+            .await
+            .expect("shared drive member may list mount");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "shared.txt");
+
+        let non_member = make_user(&pool, "non-member").await;
+        let err = folder_service
+            .list_mount_dir_with_perms(&cfg, &NodeId::default(), non_member, opts())
+            .await
+            .expect_err("non-member must be denied");
         assert_eq!(err.kind, crate::domain::errors::ErrorKind::NotFound);
     }
 

--- a/src/interfaces/api/handlers/admin_external_mounts.rs
+++ b/src/interfaces/api/handlers/admin_external_mounts.rs
@@ -1,7 +1,7 @@
 //! Admin CRUD for external file mounts (`/api/admin/external-mounts`).
 //!
 //! Creating a mount: validate the backend config, create a mount-root folder
-//! under the admin's drive, insert the `external_mounts` row, then hot-reload
+//! under the selected drive, insert the `external_mounts` row, then hot-reload
 //! the in-memory registry. Deleting: remove the row + the folder and reload.
 //! Every endpoint is admin-gated.
 
@@ -20,7 +20,7 @@ use crate::application::ports::external_mount_ports::{
     ExternalMountRecord, ExternalMountRepositoryPort, MountProviderFactory, NewExternalMount,
 };
 use crate::common::di::AppState;
-use crate::domain::repositories::drive_repository::DriveRepository;
+use crate::domain::repositories::drive_repository::{DriveRepository, DriveRepositoryError};
 use crate::domain::repositories::folder_repository::FolderRepository;
 use crate::infrastructure::repositories::pg::ExternalMountPgRepository;
 use crate::infrastructure::services::mount_provider_factory::DefaultMountProviderFactory;
@@ -60,6 +60,8 @@ impl From<ExternalMountRecord> for ExternalMountResponse {
 pub struct CreateExternalMountRequest {
     /// Display name (also the mount-root folder name).
     pub name: String,
+    /// Drive that owns the mount and controls access through its grants.
+    pub drive_id: Uuid,
     /// Absolute host path for the `local_fs` provider.
     pub host_path: String,
     /// Provider kind. Defaults to `local_fs`.
@@ -96,7 +98,7 @@ pub async fn list_external_mounts(
     Ok(Json(out))
 }
 
-/// `POST /api/admin/external-mounts` — create a mount in the admin's drive.
+/// `POST /api/admin/external-mounts` — create a mount in the selected drive.
 pub async fn create_external_mount(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -116,12 +118,19 @@ pub async fn create_external_mount(
         .await
         .map_err(|e| AppError::bad_request(format!("invalid mount configuration: {e}")))?;
 
-    // Create the mount-root folder under the admin's default drive root.
+    // The mount-root is a normal folder in the selected drive. All access to
+    // the external provider is authorized against this folder, so personal
+    // and shared drive membership automatically applies to the mount.
     let drive = state
         .drive_repo
-        .find_default_for_user(admin_id)
+        .get_by_id(req.drive_id)
         .await
-        .map_err(|e| AppError::internal_error(format!("find default drive: {e}")))?;
+        .map_err(|e| match e {
+            DriveRepositoryError::NotFound(_) => {
+                AppError::bad_request("Destination drive not found")
+            }
+            other => AppError::internal_error(format!("find destination drive: {other}")),
+        })?;
     let root_folder_id = drive.drive.root_folder_id.to_string();
 
     let folder = state
@@ -153,6 +162,7 @@ pub async fn create_external_mount(
         event = "external_mount.config",
         action = "create",
         mount_id = %mount_folder_id,
+        drive_id = %req.drive_id,
         caller_id = %admin_id,
         kind = %req.kind,
         reason = "external_mount_admin",
@@ -211,4 +221,35 @@ pub async fn delete_external_mount(
     );
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CreateExternalMountRequest;
+
+    #[test]
+    fn create_request_requires_destination_drive() {
+        let missing_drive =
+            serde_json::from_value::<CreateExternalMountRequest>(serde_json::json!({
+                "name": "Media",
+                "host_path": "/srv/media"
+            }));
+
+        assert!(missing_drive.is_err());
+    }
+
+    #[test]
+    fn create_request_accepts_destination_drive() {
+        let drive_id = uuid::Uuid::new_v4();
+        let request = serde_json::from_value::<CreateExternalMountRequest>(serde_json::json!({
+            "name": "Media",
+            "host_path": "/srv/media",
+            "drive_id": drive_id
+        }))
+        .expect("valid external mount request");
+
+        assert_eq!(request.drive_id, drive_id);
+        assert_eq!(request.kind, "local_fs");
+        assert!(!request.read_only);
+    }
 }

--- a/tests/api/external_mounts.hurl
+++ b/tests/api/external_mounts.hurl
@@ -13,7 +13,8 @@
 #   * DELETE /api/admin/external-mounts/{id}   — delete
 #
 # This test pins:
-#   * Input validation: empty name → 400; non-existent host
+#   * Input validation: missing destination drive → 422;
+#     empty name → 400; non-existent host
 #     path (invalid provider config) → 400.
 #   * Create returns 201 with the full mount view; the mount is
 #     then visible in the list with the config echoed back.
@@ -40,6 +41,17 @@ HTTP 200
 admin_token: jsonpath "$.access_token"
 
 
+# Select the admin's default Personal drive as the destination.
+GET {{base_url}}/api/drives
+Authorization: Bearer {{admin_token}}
+
+HTTP 200
+[Captures]
+drive_id: jsonpath "$[0].id"
+[Asserts]
+jsonpath "$[0].kind" == "personal"
+
+
 # Anti-enum registration (200 whether or not it already exists).
 POST {{base_url}}/api/auth/register
 Content-Type: application/json
@@ -61,6 +73,15 @@ HTTP 200
 bob_token: jsonpath "$.access_token"
 
 
+# A destination drive is required; reject the old request shape.
+POST {{base_url}}/api/admin/external-mounts
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{ "name": "missing-drive", "host_path": "/tmp" }
+
+HTTP 422
+
+
 # ─────────────────────────────────────────────────────────────
 # Step 1 — Validation: empty name is rejected before any
 #          filesystem or DB work happens.
@@ -68,7 +89,7 @@ bob_token: jsonpath "$.access_token"
 POST {{base_url}}/api/admin/external-mounts
 Authorization: Bearer {{admin_token}}
 Content-Type: application/json
-{ "name": "", "host_path": "/tmp" }
+{ "name": "", "host_path": "/tmp", "drive_id": "{{drive_id}}" }
 
 HTTP 400
 
@@ -80,7 +101,7 @@ HTTP 400
 POST {{base_url}}/api/admin/external-mounts
 Authorization: Bearer {{admin_token}}
 Content-Type: application/json
-{ "name": "bad-mount", "host_path": "/no/such/path/oxicloud-does-not-exist" }
+{ "name": "bad-mount", "host_path": "/no/such/path/oxicloud-does-not-exist", "drive_id": "{{drive_id}}" }
 
 HTTP 400
 
@@ -92,7 +113,7 @@ HTTP 400
 POST {{base_url}}/api/admin/external-mounts
 Authorization: Bearer {{admin_token}}
 Content-Type: application/json
-{ "name": "hurl-mount-test", "host_path": "/tmp", "read_only": true }
+{ "name": "hurl-mount-test", "host_path": "/tmp", "read_only": true, "drive_id": "{{drive_id}}" }
 
 HTTP 201
 [Captures]
@@ -103,7 +124,7 @@ jsonpath "$.name"            == "hurl-mount-test"
 jsonpath "$.kind"            == "local_fs"
 jsonpath "$.read_only"       == true
 jsonpath "$.owner_id"        isString
-jsonpath "$.drive_id"        isString
+jsonpath "$.drive_id"        == "{{drive_id}}"
 jsonpath "$.mount_path"      isString
 jsonpath "$.config.path"     == "/tmp"
 
@@ -125,6 +146,7 @@ jsonpath "$[0].mount_folder_id" == "{{mount_id}}"
 jsonpath "$[0].name"            == "hurl-mount-test"
 jsonpath "$[0].read_only"       == true
 jsonpath "$[0].kind"            == "local_fs"
+jsonpath "$[0].drive_id"        == "{{drive_id}}"
 jsonpath "$[0].config.path"     == "/tmp"
 
 
@@ -142,7 +164,7 @@ HTTP 403
 POST {{base_url}}/api/admin/external-mounts
 Authorization: Bearer {{bob_token}}
 Content-Type: application/json
-{ "name": "bob-mount", "host_path": "/tmp" }
+{ "name": "bob-mount", "host_path": "/tmp", "drive_id": "{{drive_id}}" }
 
 HTTP 403
 


### PR DESCRIPTION
## Summary

- require administrators to choose a destination drive when creating an external mount
- create the mount root beneath that drive so existing drive roles govern provider access
- show the selected drive in the admin UI and document upgrade behavior
- migrate the legacy visibility marker from `owner` to `drive`

## Tests

- `just check`
- `just test`
- `just test-integration shared_drive_member_lists_mount_non_member_denied`
- `npm run check`
- `npm run test:unit`

Closes #685